### PR TITLE
Cleaning up benchmark output

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,8 @@ To run all benchmarks, run the benchmark task and pass in a list of hosts.
 
 For example:
 ```
-./gradlew benchmark -Phosts=localhost,localhost,localhost
+./gradlew benchmark -Phosts=localhost,localhost,localhost -PoutputDir=/tmp/results
 ```
-
-Performance results will be written to geode-benchmarks/output
 
 ## Project structure
 

--- a/geode-benchmarks/build.gradle
+++ b/geode-benchmarks/build.gradle
@@ -43,7 +43,10 @@ task benchmark(type: Test) {
         exceptionFormat = 'full'
     }
 
+    def outputDir = project.hasProperty('outputDir') ? project.findProperty('outputDir') : new File(project.buildDir, "benchmarks").getAbsolutePath();
+
     systemProperty 'TEST_HOSTS', project.findProperty('hosts');
+    systemProperty 'OUTPUT_DIR', outputDir;
 
     doFirst {
         if(!project.hasProperty('hosts')) {

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/GetTask.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/GetTask.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geode.benchmark.tasks;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import org.yardstickframework.BenchmarkConfiguration;
+import org.yardstickframework.BenchmarkDriverAdapter;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientCacheFactory;
+
+public class GetTask extends BenchmarkDriverAdapter implements Serializable {
+
+  private Region<Object, Object> region;
+
+  @Override
+  public void setUp(BenchmarkConfiguration cfg) throws Exception {
+    super.setUp(cfg);
+    ClientCache cache = ClientCacheFactory.getAnyInstance();
+    region = cache.getRegion("region");
+  }
+
+  @Override
+  public boolean test(Map<Object, Object> ctx) throws Exception {
+    region.get(1);
+    return true;
+  }
+}

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartClient.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartClient.java
@@ -17,6 +17,7 @@
 
 package org.apache.geode.benchmark.tasks;
 
+import java.io.File;
 import java.net.InetAddress;
 
 import org.apache.geode.cache.client.ClientCache;
@@ -38,10 +39,12 @@ public class StartClient implements Task {
 
     InetAddress locator = context.getHostsForRole("locator").iterator().next();
 
+    String statsFile = new File(context.getOutputDir(), "stats.gfs").getAbsolutePath();
+
     ClientCache clientCache = new ClientCacheFactory()
         .addPoolLocator(locator.getHostAddress(), locatorPort)
         .set(ConfigurationProperties.STATISTIC_SAMPLING_ENABLED,"true")
-        .set(ConfigurationProperties.STATISTIC_ARCHIVE_FILE,"output/stats.gfs")
+        .set(ConfigurationProperties.STATISTIC_ARCHIVE_FILE, statsFile)
         .create();
 
     clientCache.createClientRegionFactory(ClientRegionShortcut.PROXY)

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartLocator.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartLocator.java
@@ -17,6 +17,7 @@
 
 package org.apache.geode.benchmark.tasks;
 
+import java.io.File;
 import java.net.InetAddress;
 import java.util.Properties;
 
@@ -35,9 +36,12 @@ public class StartLocator implements Task {
   @Override
   public void run(TestContext context) throws Exception {
     Properties properties = new Properties();
-    properties.setProperty(ConfigurationProperties.NAME,"locator-"+ InetAddress.getLocalHost());
+
+    String statsFile = new File(context.getOutputDir(), "stats.gfs").getAbsolutePath();
     properties.setProperty(ConfigurationProperties.STATISTIC_SAMPLING_ENABLED,"true");
-    properties.setProperty(ConfigurationProperties.STATISTIC_ARCHIVE_FILE,"output/stats.gfs");
+    properties.setProperty(ConfigurationProperties.STATISTIC_ARCHIVE_FILE, statsFile);
+
+    properties.setProperty(ConfigurationProperties.NAME,"locator-"+ InetAddress.getLocalHost());
     Locator.startLocatorAndDS(locatorPort, null, properties);
   }
 }

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartServer.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartServer.java
@@ -17,6 +17,7 @@
 
 package org.apache.geode.benchmark.tasks;
 
+import java.io.File;
 import java.net.InetAddress;
 
 import org.apache.geode.cache.Cache;
@@ -39,12 +40,13 @@ public class StartServer implements Task {
   public void run(TestContext context) throws Exception {
 
     String locatorString = LocatorUtil.getLocatorString(context, locatorPort);
+    String statsFile = new File(context.getOutputDir(), "stats.gfs").getAbsolutePath();
 
     Cache cache = new CacheFactory()
         .set(ConfigurationProperties.LOCATORS,locatorString)
         .set(ConfigurationProperties.NAME,"server-"+ InetAddress.getLocalHost())
         .set(ConfigurationProperties.STATISTIC_SAMPLING_ENABLED,"true")
-        .set(ConfigurationProperties.STATISTIC_ARCHIVE_FILE,"output/stats.gfs")
+        .set(ConfigurationProperties.STATISTIC_ARCHIVE_FILE, statsFile)
         .create();
 
     CacheServer cacheServer = ((Cache) cache).addCacheServer();

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedGetBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedGetBenchmark.java
@@ -19,14 +19,20 @@ package org.apache.geode.benchmark.tests;
 
 import org.junit.Test;
 
-import org.apache.geode.benchmark.tasks.PutTask;
+import org.apache.geode.benchmark.tasks.GetTask;
 import org.apache.geode.benchmark.tasks.StartClient;
 import org.apache.geode.benchmark.tasks.StartLocator;
 import org.apache.geode.benchmark.tasks.StartServer;
 import org.apache.geode.perftest.TestConfig;
 import org.apache.geode.perftest.TestRunners;
 
-public class PartitionedPutBenchmark {
+/**
+ * Benchmark of gets on a partitioned region.
+ *
+ * TODO - this is not populating the region!
+ * TODO - this is only getting a single key!
+ */
+public class PartitionedGetBenchmark {
 
   @Test
   public void run() throws Exception {
@@ -37,7 +43,7 @@ public class PartitionedPutBenchmark {
 
     int locatorPort = 10334;
 
-    config.name(PartitionedPutBenchmark.class.getCanonicalName());
+    config.name(PartitionedGetBenchmark.class.getCanonicalName());
     config.warmupSeconds(2);
     config.durationSeconds(5);
     config.role("locator", 1);
@@ -46,6 +52,6 @@ public class PartitionedPutBenchmark {
     config.before(new StartLocator(locatorPort), "locator");
     config.before(new StartServer(locatorPort), "server");
     config.before(new StartClient(locatorPort), "client");
-    config.workload(new PutTask(),"client");
+    config.workload(new GetTask(),"client");
   }
 }

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedPutBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedPutBenchmark.java
@@ -37,6 +37,7 @@ public class PartitionedPutBenchmark {
 
     int locatorPort = 10334;
 
+    config.name(PartitionedPutBenchmark.class.getCanonicalName());
     config.warmupSeconds(5);
     config.durationSeconds(30);
     config.role("locator", 1);

--- a/harness/src/main/java/org/apache/geode/perftest/TestConfig.java
+++ b/harness/src/main/java/org/apache/geode/perftest/TestConfig.java
@@ -78,7 +78,7 @@ public class TestConfig implements Serializable {
    * @param roles The roles to run the workload on
    */
   public void workload(BenchmarkDriver benchmark, String ... roles) {
-    workload.add(new TestStep(new YardstickTask(benchmark, workloadConfig, "output"), roles));
+    workload.add(new TestStep(new YardstickTask(benchmark, workloadConfig), roles));
   }
 
 

--- a/harness/src/main/java/org/apache/geode/perftest/TestConfig.java
+++ b/harness/src/main/java/org/apache/geode/perftest/TestConfig.java
@@ -39,6 +39,7 @@ public class TestConfig implements Serializable {
   private List<TestStep> before = new ArrayList<>();
   private List<TestStep> workload = new ArrayList<>();
   private List<TestStep> after = new ArrayList<>();
+  private String name;
 
   /**
    * Define a role for the test.
@@ -77,7 +78,7 @@ public class TestConfig implements Serializable {
    * @param roles The roles to run the workload on
    */
   public void workload(BenchmarkDriver benchmark, String ... roles) {
-    workload.add(new TestStep(new YardstickTask(benchmark, workloadConfig), roles));
+    workload.add(new TestStep(new YardstickTask(benchmark, workloadConfig, "output"), roles));
   }
 
 
@@ -108,6 +109,14 @@ public class TestConfig implements Serializable {
     workloadConfig.warmupSeconds(warmupSeconds);
   }
 
+  /**
+   * Set the name of this benchmark. This name must be unique within a benchmarking run. Comparisons
+   * between runs will use this name to identify the same benchmark in both runs.
+   */
+  public void name(String name) {
+    this.name = name;
+  }
+
   public long getDurationSeconds() {
     return workloadConfig.getDurationSeconds();
   }
@@ -130,6 +139,10 @@ public class TestConfig implements Serializable {
 
   public List<TestStep> getAfter() {
     return after;
+  }
+
+  public String getName() {
+    return name;
   }
 
   /**

--- a/harness/src/main/java/org/apache/geode/perftest/TestContext.java
+++ b/harness/src/main/java/org/apache/geode/perftest/TestContext.java
@@ -17,10 +17,13 @@
 
 package org.apache.geode.perftest;
 
+import java.io.File;
 import java.io.Serializable;
 import java.net.InetAddress;
 import java.util.Set;
 
 public interface TestContext extends Serializable {
   Set<InetAddress> getHostsForRole(String role);
+
+  File getOutputDir();
 }

--- a/harness/src/main/java/org/apache/geode/perftest/TestRunners.java
+++ b/harness/src/main/java/org/apache/geode/perftest/TestRunners.java
@@ -38,11 +38,12 @@ import org.apache.geode.perftest.runner.DefaultTestRunner;
 public class TestRunners {
 
   public static final String TEST_HOSTS = "TEST_HOSTS";
+  public static final String OUTPUT_DIR = "OUTPUT_DIR";
 
 
-  public static TestRunner defaultRunner(String username, String ... hosts) {
+  public static TestRunner defaultRunner(String username, File outputDir, String ... hosts) {
     return new DefaultTestRunner(new RemoteJVMFactory(new SshInfrastructureFactory(username, hosts)),
-        new File("output"));
+        outputDir);
   }
   /**
    * The default runner, which gets a list of hosts to run on from the
@@ -51,17 +52,18 @@ public class TestRunners {
    */
   public static TestRunner defaultRunner() {
     String testHosts = System.getProperty(TEST_HOSTS);
+    String outputDir = System.getProperty(OUTPUT_DIR, "output");
 
-    return defaultRunner(testHosts);
+    return defaultRunner(testHosts, new File(outputDir));
   }
 
-  static TestRunner defaultRunner(String testHosts) {
+  static TestRunner defaultRunner(String testHosts, File outputDir) {
     if(testHosts == null) {
       throw new IllegalStateException("You must set the TEST_HOSTS system property to a comma separated list of hosts to run the benchmarks on.");
     }
 
     String userName = System.getProperty("user.name");
-    return defaultRunner(userName, testHosts.split(",\\s*"));
+    return defaultRunner(userName, outputDir, testHosts.split(",\\s*"));
   }
 
   /**

--- a/harness/src/main/java/org/apache/geode/perftest/TestRunners.java
+++ b/harness/src/main/java/org/apache/geode/perftest/TestRunners.java
@@ -17,7 +17,8 @@
 
 package org.apache.geode.perftest;
 
-import org.apache.geode.perftest.infrastructure.InfrastructureFactory;
+import java.io.File;
+
 import org.apache.geode.perftest.infrastructure.local.LocalInfrastructureFactory;
 import org.apache.geode.perftest.infrastructure.ssh.SshInfrastructureFactory;
 import org.apache.geode.perftest.jvms.RemoteJVMFactory;
@@ -40,7 +41,8 @@ public class TestRunners {
 
 
   public static TestRunner defaultRunner(String username, String ... hosts) {
-    return new DefaultTestRunner(new SshInfrastructureFactory(username, hosts), new RemoteJVMFactory());
+    return new DefaultTestRunner(new SshInfrastructureFactory(username, hosts), new RemoteJVMFactory(),
+        new File("output"));
   }
   /**
    * The default runner, which gets a list of hosts to run on from the
@@ -65,9 +67,11 @@ public class TestRunners {
   /**
    * A test runner that runs the test with the minimal tuning - only
    * 1 second duration on local infrastructure.
+   * @param outputDir
    */
-  public static TestRunner minimalRunner() {
-    return new DefaultTestRunner(new LocalInfrastructureFactory(), new RemoteJVMFactory()) {
+  public static TestRunner minimalRunner(final File outputDir) {
+    return new DefaultTestRunner(new LocalInfrastructureFactory(), new RemoteJVMFactory(),
+        outputDir) {
       @Override
       public void runTest(TestConfig config) throws Exception {
         config.warmupSeconds(0);

--- a/harness/src/main/java/org/apache/geode/perftest/TestRunners.java
+++ b/harness/src/main/java/org/apache/geode/perftest/TestRunners.java
@@ -41,7 +41,7 @@ public class TestRunners {
 
 
   public static TestRunner defaultRunner(String username, String ... hosts) {
-    return new DefaultTestRunner(new SshInfrastructureFactory(username, hosts), new RemoteJVMFactory(),
+    return new DefaultTestRunner(new RemoteJVMFactory(new SshInfrastructureFactory(username, hosts)),
         new File("output"));
   }
   /**
@@ -70,8 +70,7 @@ public class TestRunners {
    * @param outputDir
    */
   public static TestRunner minimalRunner(final File outputDir) {
-    return new DefaultTestRunner(new LocalInfrastructureFactory(), new RemoteJVMFactory(),
-        outputDir) {
+    return new DefaultTestRunner(new RemoteJVMFactory(new LocalInfrastructureFactory()), outputDir) {
       @Override
       public void runTest(TestConfig config) throws Exception {
         config.warmupSeconds(0);

--- a/harness/src/main/java/org/apache/geode/perftest/infrastructure/Infrastructure.java
+++ b/harness/src/main/java/org/apache/geode/perftest/infrastructure/Infrastructure.java
@@ -43,9 +43,14 @@ public interface Infrastructure extends AutoCloseable {
   void close() throws InterruptedException, IOException;
 
   /**
-   * Copy a list of files to a directory on the node
+   * Copy a list of files to a directory on the node.
+   *
+   * @param files A list of files on the local system to copy
+   * @param destDir The directory on the remote machine to copy to
+   * @param removeExisting If true, remove all existing files in the directory on the remote
+   * machine
    */
-  void copyToNodes(Iterable<File> files, String destDir) throws IOException;
+  void copyToNodes(Iterable<File> files, String destDir, boolean removeExisting) throws IOException;
 
   void copyFromNode(Node node, String directory, File destDir) throws IOException;
 

--- a/harness/src/main/java/org/apache/geode/perftest/infrastructure/local/LocalInfrastructure.java
+++ b/harness/src/main/java/org/apache/geode/perftest/infrastructure/local/LocalInfrastructure.java
@@ -24,9 +24,9 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -85,10 +85,10 @@ public class LocalInfrastructure implements Infrastructure {
   }
 
   @Override
-  public void copyToNodes(Iterable<File> files, String destDirName) throws IOException {
+  public void copyToNodes(Iterable<File> files, String destDirName, boolean removeExisting) throws IOException {
     for(LocalNode node : nodes) {
       Path destDir = new File(node.getWorkingDir(), destDirName).toPath();
-      destDir.toFile().mkdir();
+      destDir.toFile().mkdirs();
 
       for(File file : files) {
         Files.copy(file.toPath(), destDir.resolve(file.getName()));

--- a/harness/src/main/java/org/apache/geode/perftest/jdk/SystemInterface.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jdk/SystemInterface.java
@@ -24,7 +24,7 @@ import java.io.PrintStream;
  */
 public class SystemInterface {
 
-  public static String getProperty(String property) {
+  public String getProperty(String property) {
     return System.getProperty(property);
   }
 

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/JVMLauncher.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/JVMLauncher.java
@@ -32,20 +32,24 @@ import org.apache.geode.perftest.jvms.rmi.ChildJVM;
 class JVMLauncher {
   private static final Logger logger = LoggerFactory.getLogger(RemoteJVMFactory.class);
 
+  JVMLauncher() {
+  }
+
   CompletableFuture<Void> launchProcesses(Infrastructure infra, int rmiPort,
-                                          List<JVMMapping> mapping)
+                                          List<JVMMapping> mapping, String libDir)
       throws UnknownHostException {
     List<CompletableFuture<Void>> futures = new ArrayList<CompletableFuture<Void>>();
     for (JVMMapping entry : mapping) {
-      futures.add(launchWorker(infra, rmiPort, entry.getId(), entry.getNode()));
+      futures.add(launchWorker(infra, rmiPort, entry.getId(), entry.getNode(), libDir));
     }
     return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
   }
 
   CompletableFuture<Void> launchWorker(Infrastructure infra, int rmiPort,
-                                       int id, final Infrastructure.Node node)
+                                       int id, final Infrastructure.Node node, String libDir)
       throws UnknownHostException {
-    String[] shellCommand = buildCommand(InetAddress.getLocalHost().getHostAddress(), rmiPort, id);
+    String[] shellCommand = buildCommand(InetAddress.getLocalHost().getHostAddress(), rmiPort, id,
+        libDir);
     CompletableFuture<Void> future = new CompletableFuture<Void>();
     Thread thread = new Thread("Worker " + node.getAddress()) {
       public void run() {
@@ -67,12 +71,12 @@ class JVMLauncher {
     return future;
   }
 
-  String[] buildCommand(String rmiHost, int rmiPort, int id) {
+  String[] buildCommand(String rmiHost, int rmiPort, int id, String libDir) {
 
     List<String> command = new ArrayList<String>();
     command.add("java");
     command.add("-classpath");
-    command.add("lib/*");
+    command.add(libDir + "/*");
     command.add("-D" + RemoteJVMFactory.RMI_HOST + "=" + rmiHost);
     command.add("-D" + RemoteJVMFactory.RMI_PORT_PROPERTY + "=" + rmiPort);
     command.add("-D" + RemoteJVMFactory.JVM_ID + "=" + id);

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/JVMLauncher.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/JVMLauncher.java
@@ -40,16 +40,17 @@ class JVMLauncher {
       throws UnknownHostException {
     List<CompletableFuture<Void>> futures = new ArrayList<CompletableFuture<Void>>();
     for (JVMMapping entry : mapping) {
-      futures.add(launchWorker(infra, rmiPort, entry.getId(), entry.getNode(), libDir));
+      futures.add(launchWorker(infra, rmiPort, entry.getId(), entry.getNode(), libDir, entry.getOutputDir()));
     }
     return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
   }
 
   CompletableFuture<Void> launchWorker(Infrastructure infra, int rmiPort,
-                                       int id, final Infrastructure.Node node, String libDir)
+                                       int id, final Infrastructure.Node node, String libDir,
+                                       String outputDir)
       throws UnknownHostException {
     String[] shellCommand = buildCommand(InetAddress.getLocalHost().getHostAddress(), rmiPort, id,
-        libDir);
+        libDir, outputDir);
     CompletableFuture<Void> future = new CompletableFuture<Void>();
     Thread thread = new Thread("Worker " + node.getAddress()) {
       public void run() {
@@ -71,7 +72,8 @@ class JVMLauncher {
     return future;
   }
 
-  String[] buildCommand(String rmiHost, int rmiPort, int id, String libDir) {
+  String[] buildCommand(String rmiHost, int rmiPort, int id, String libDir,
+                        String outputDir) {
 
     List<String> command = new ArrayList<String>();
     command.add("java");
@@ -80,6 +82,7 @@ class JVMLauncher {
     command.add("-D" + RemoteJVMFactory.RMI_HOST + "=" + rmiHost);
     command.add("-D" + RemoteJVMFactory.RMI_PORT_PROPERTY + "=" + rmiPort);
     command.add("-D" + RemoteJVMFactory.JVM_ID + "=" + id);
+    command.add("-D" + RemoteJVMFactory.OUTPUT_DIR + "=" + outputDir);
     command.add(ChildJVM.class.getName());
 
     return command.toArray(new String[0]);

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/JVMMapping.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/JVMMapping.java
@@ -44,4 +44,7 @@ public class JVMMapping implements Serializable {
     return id;
   }
 
+  public String getOutputDir() {
+    return "output/" + role + "-" + id;
+  }
 }

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/RemoteJVMFactory.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/RemoteJVMFactory.java
@@ -33,6 +33,7 @@ import org.apache.geode.perftest.infrastructure.InfrastructureFactory;
 import org.apache.geode.perftest.jvms.classpath.ClassPathCopier;
 import org.apache.geode.perftest.jvms.rmi.Controller;
 import org.apache.geode.perftest.jvms.rmi.ControllerFactory;
+import org.apache.geode.perftest.runner.SharedContext;
 
 /**
  * Factory for launching JVMs and a given infrastructure and setting up RMI
@@ -85,11 +86,12 @@ public class RemoteJVMFactory {
       throw new IllegalStateException("Too few nodes for test. Need " + numWorkers + ", have " + nodes.size());
     }
 
-    Controller controller = controllerFactory.createController(numWorkers);
+    List<JVMMapping> mapping = mapRolesToNodes(roles, nodes);
+
+    Controller controller = controllerFactory.createController(new SharedContext(mapping), numWorkers);
 
     classPathCopier.copyToNodes(infra, LIB_DIR);
 
-    List<JVMMapping> mapping = mapRolesToNodes(roles, nodes);
     CompletableFuture<Void> processesExited = jvmLauncher.launchProcesses(infra, RMI_PORT, mapping,
         LIB_DIR);
 

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/RemoteJVMFactory.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/RemoteJVMFactory.java
@@ -45,6 +45,7 @@ public class RemoteJVMFactory {
   public static final String RMI_HOST = "RMI_HOST";
   public static final String RMI_PORT_PROPERTY = "RMI_PORT";
   public static final String CONTROLLER = "CONTROLLER";
+  public static final String OUTPUT_DIR = "OUTPUT_DIR";
   public static final String JVM_ID = "JVM_ID";
   public static final int RMI_PORT = 33333;
   public static final String CLASSPATH = System.getProperty("java.class.path");

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/RemoteJVMFactory.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/RemoteJVMFactory.java
@@ -17,7 +17,6 @@
 
 package org.apache.geode.perftest.jvms;
 
-import java.rmi.registry.Registry;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -49,6 +48,7 @@ public class RemoteJVMFactory {
   public static final int RMI_PORT = 33333;
   public static final String CLASSPATH = System.getProperty("java.class.path");
   public static final String JAVA_HOME = System.getProperty("java.home");
+  private static final String LIB_DIR = ".geode-performance/lib";
   private final JVMLauncher jvmLauncher;
   private final ClassPathCopier classPathCopier;
   private final ControllerFactory controllerFactory;
@@ -84,10 +84,11 @@ public class RemoteJVMFactory {
 
     Controller controller = controllerFactory.createController(numWorkers);
 
-    classPathCopier.copyToNodes(infra);
+    classPathCopier.copyToNodes(infra, LIB_DIR);
 
     List<JVMMapping> mapping = mapRolesToNodes(roles, nodes);
-    CompletableFuture<Void> processesExited = jvmLauncher.launchProcesses(infra, RMI_PORT, mapping);
+    CompletableFuture<Void> processesExited = jvmLauncher.launchProcesses(infra, RMI_PORT, mapping,
+        LIB_DIR);
 
     if(!controller.waitForWorkers(5, TimeUnit.MINUTES)) {
       throw new IllegalStateException("Workers failed to start in 1 minute");

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/RemoteJVMs.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/RemoteJVMs.java
@@ -19,9 +19,6 @@ package org.apache.geode.perftest.jvms;
 
 import java.io.File;
 import java.io.IOException;
-import java.rmi.NoSuchObjectException;
-import java.rmi.registry.Registry;
-import java.rmi.server.UnicastRemoteObject;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -42,7 +39,6 @@ import org.apache.geode.perftest.runner.DefaultTestContext;
 public class RemoteJVMs implements AutoCloseable {
   private final List<JVMMapping> jvmMappings;
   private final Controller controller;
-  private final TestContext context;
   private final CompletableFuture<Void> exited;
   private final Infrastructure infra;
 
@@ -53,7 +49,6 @@ public class RemoteJVMs implements AutoCloseable {
     this.infra = infra;
     this.jvmMappings = mapping;
     this.controller = controller;
-    this.context = new DefaultTestContext(jvmMappings);
     this.exited = exited;
   }
 
@@ -66,7 +61,7 @@ public class RemoteJVMs implements AutoCloseable {
 
     Stream<CompletableFuture> futures = jvmMappings.stream()
         .filter(mapping -> roles.contains(mapping.getRole()))
-        .map(mapping -> controller.onWorker(mapping.getId(), task, context));
+        .map(mapping -> controller.onWorker(mapping.getId(), task));
 
     futures.forEach(CompletableFuture::join);
   }

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/RemoteJVMs.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/RemoteJVMs.java
@@ -72,21 +72,13 @@ public class RemoteJVMs implements AutoCloseable {
     exited.get();
   }
 
-  public String getRole(Infrastructure.Node node) {
-    return jvmMappings.stream()
-        .filter(mapping -> mapping.getNode().equals(node))
-        .map(JVMMapping::getRole)
-        .findFirst()
-        .orElse("no-role");
-  }
-
   /**
    * Copy results to the provided output directory
    */
   public void copyResults(File benchmarkOutput) throws IOException {
     benchmarkOutput.mkdirs();
     for (JVMMapping jvm : jvmMappings) {
-      infra.copyFromNode(jvm.getNode(), "output", new File(benchmarkOutput, jvm.getRole() + "-" + jvm.getId()));
+      infra.copyFromNode(jvm.getNode(), jvm.getOutputDir(), new File(benchmarkOutput, jvm.getRole() + "-" + jvm.getId()));
     }
   }
 }

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/classpath/ClassPathCopier.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/classpath/ClassPathCopier.java
@@ -42,10 +42,9 @@ public class ClassPathCopier {
   /**
    * Copy the current classpath to a lib directory on all of the nodes in the infrastructure
    */
-  public void copyToNodes(Infrastructure infrastructure) throws IOException {
+  public void copyToNodes(Infrastructure infrastructure, String destDir) throws IOException {
     String[] fileArray = classpath.split(File.pathSeparator);
 
-    String destDir = "lib";
     Iterable<File> files = Arrays.asList(fileArray)
         .stream()
         .filter(path -> !path.contains(javaHome))
@@ -54,7 +53,7 @@ public class ClassPathCopier {
         .filter(File::exists)
         .collect(Collectors.toSet());
 
-    infrastructure.copyToNodes(files, destDir);
+    infrastructure.copyToNodes(files, destDir, true);
   }
 
   private File jarDir(File file) {

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/ChildJVM.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/ChildJVM.java
@@ -33,15 +33,17 @@ public class ChildJVM {
   private final RMI rmi;
   private final SystemInterface system;
   private final int pingTime;
+  private final File outputDir;
 
-  public ChildJVM(RMI rmi, SystemInterface system, int pingTime) {
+  public ChildJVM(RMI rmi, SystemInterface system, int pingTime, File outputDir) {
     this.rmi = rmi;
     this.system = system;
     this.pingTime = pingTime;
+    this.outputDir = outputDir;
   }
 
   public static void main(String[] args) {
-    new ChildJVM(new RMI(), new SystemInterface(), 1000).run();
+    new ChildJVM(new RMI(), new SystemInterface(), 1000, new File("output")).run();
   }
 
   void run() {
@@ -49,7 +51,6 @@ public class ChildJVM {
       String RMI_HOST = system.getProperty(RemoteJVMFactory.RMI_HOST);
       String RMI_PORT = system.getProperty(RemoteJVMFactory.RMI_PORT_PROPERTY);
       int id = system.getInteger(RemoteJVMFactory.JVM_ID);
-      File outputDir = new File("output");
       outputDir.mkdirs();
       PrintStream out = new PrintStream(new File(outputDir, "ChildJVM-" + id + ".txt"));
       system.setOut(out);

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/ChildJVM.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/ChildJVM.java
@@ -65,7 +65,7 @@ public class ChildJVM {
       //Clean up the output directory before the test runs
       FileUtils.deleteQuietly(outputDir);
       outputDir.mkdirs();
-      PrintStream out = new PrintStream(new File(outputDir, "ChildJVM-" + id + ".txt"));
+      PrintStream out = new PrintStream(new File(outputDir, "system.log"));
       system.setOut(out);
       system.setErr(out);
 

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/ChildJVM.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/ChildJVM.java
@@ -20,9 +20,13 @@ package org.apache.geode.perftest.jvms.rmi;
 import java.io.File;
 import java.io.PrintStream;
 
+import org.bouncycastle.jcajce.provider.drbg.DRBG;
+
 import org.apache.geode.perftest.jdk.RMI;
 import org.apache.geode.perftest.jdk.SystemInterface;
 import org.apache.geode.perftest.jvms.RemoteJVMFactory;
+import org.apache.geode.perftest.runner.DefaultTestContext;
+import org.apache.geode.perftest.runner.SharedContext;
 
 /**
  * Main method for a JVM running on a remote node
@@ -59,7 +63,10 @@ public class ChildJVM {
       ControllerRemote controller = (ControllerRemote) rmi
           .lookup("//" + RMI_HOST + ":" + RMI_PORT + "/" + RemoteJVMFactory.CONTROLLER);
 
-      Worker worker = new Worker();
+      SharedContext sharedContext = controller.getsharedContext();
+      DefaultTestContext context = new DefaultTestContext(sharedContext);
+
+      Worker worker = new Worker(context);
 
       controller.addWorker(id, worker);
 

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/ControllerFactory.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/ControllerFactory.java
@@ -25,14 +25,16 @@ import java.rmi.RemoteException;
 import java.rmi.registry.Registry;
 
 import org.apache.geode.perftest.jdk.RMI;
+import org.apache.geode.perftest.runner.SharedContext;
 
 public class ControllerFactory {
 
   private final RMI rmi = new RMI();
 
-  public Controller createController(int numWorkers) throws RemoteException, AlreadyBoundException {
+  public Controller createController(SharedContext sharedContext,
+                                     int numWorkers) throws RemoteException, AlreadyBoundException {
     Registry registry = rmi.createRegistry(RMI_PORT);
-    Controller controller = new Controller(numWorkers, registry);
+    Controller controller = new Controller(numWorkers, registry, sharedContext);
     registry.bind(CONTROLLER, controller);
     return controller;
   }

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/ControllerRemote.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/ControllerRemote.java
@@ -20,9 +20,13 @@ package org.apache.geode.perftest.jvms.rmi;
 import java.rmi.Remote;
 import java.rmi.RemoteException;
 
+import org.apache.geode.perftest.runner.SharedContext;
+
 public interface ControllerRemote extends Remote {
 
   void addWorker(int id, WorkerRemote remote) throws RemoteException;
 
   boolean ping() throws RemoteException;
+
+  SharedContext getsharedContext() throws RemoteException;
 }

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/Worker.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/Worker.java
@@ -21,15 +21,17 @@ import java.rmi.RemoteException;
 import java.rmi.server.UnicastRemoteObject;
 
 import org.apache.geode.perftest.Task;
-import org.apache.geode.perftest.TestContext;
+import org.apache.geode.perftest.runner.DefaultTestContext;
 
 public class Worker extends UnicastRemoteObject implements WorkerRemote {
 
-  public Worker() throws RemoteException {
-    super();
+  private DefaultTestContext context;
+
+  public Worker(DefaultTestContext context) throws RemoteException {
+    this.context = context;
   }
   @Override
-  public void execute(Task task, TestContext context) throws Exception {
+  public void execute(Task task) throws Exception {
     task.run(context);
   }
 }

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/WorkerRemote.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/WorkerRemote.java
@@ -20,8 +20,7 @@ package org.apache.geode.perftest.jvms.rmi;
 import java.rmi.Remote;
 
 import org.apache.geode.perftest.Task;
-import org.apache.geode.perftest.TestContext;
 
 public interface WorkerRemote extends Remote {
-  void execute(Task task, TestContext context) throws Exception;
+  void execute(Task task) throws Exception;
 }

--- a/harness/src/main/java/org/apache/geode/perftest/runner/DefaultTestContext.java
+++ b/harness/src/main/java/org/apache/geode/perftest/runner/DefaultTestContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.geode.perftest.runner;
 
+import java.io.File;
 import java.net.InetAddress;
 import java.util.Set;
 
@@ -25,13 +26,20 @@ import org.apache.geode.perftest.TestContext;
 public class DefaultTestContext implements TestContext {
 
   private SharedContext sharedContext;
+  private File outputDir;
 
-  public DefaultTestContext(SharedContext sharedContext) {
+  public DefaultTestContext(SharedContext sharedContext, File outputDir) {
     this.sharedContext = sharedContext;
+    this.outputDir = outputDir;
   }
 
   @Override
   public Set<InetAddress> getHostsForRole(String role) {
     return sharedContext.getHostsForRole(role);
+  }
+
+  @Override
+  public File getOutputDir() {
+    return outputDir;
   }
 }

--- a/harness/src/main/java/org/apache/geode/perftest/runner/SharedContext.java
+++ b/harness/src/main/java/org/apache/geode/perftest/runner/SharedContext.java
@@ -17,21 +17,32 @@
 
 package org.apache.geode.perftest.runner;
 
+import java.io.Serializable;
 import java.net.InetAddress;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import org.apache.geode.perftest.TestContext;
+import org.apache.geode.perftest.jvms.JVMMapping;
 
-public class DefaultTestContext implements TestContext {
+/**
+ * Context for a running test that is the same for all JVMs
+ * running the test. This context is created at the beginning of the
+ * test run and passed to all JVMs.
+ */
+public class SharedContext implements Serializable {
 
-  private SharedContext sharedContext;
+  private List<JVMMapping> jvmMappings;
 
-  public DefaultTestContext(SharedContext sharedContext) {
-    this.sharedContext = sharedContext;
+  public SharedContext(List<JVMMapping> jvmMappings) {
+
+    this.jvmMappings = jvmMappings;
   }
 
-  @Override
   public Set<InetAddress> getHostsForRole(String role) {
-    return sharedContext.getHostsForRole(role);
+    return jvmMappings.stream()
+        .filter(mapping -> mapping.getRole().equals(role))
+        .map(mapping -> mapping.getNode().getAddress())
+        .collect(Collectors.toSet());
   }
 }

--- a/harness/src/main/java/org/apache/geode/perftest/yardstick/YardstickTask.java
+++ b/harness/src/main/java/org/apache/geode/perftest/yardstick/YardstickTask.java
@@ -42,11 +42,13 @@ import org.apache.geode.perftest.WorkloadConfig;
  */
 public class YardstickTask implements Task {
   private final BenchmarkDriver benchmark;
+  private final String outputDir;
   private WorkloadConfig workloadConfig;
 
-  public YardstickTask(BenchmarkDriver benchmark, WorkloadConfig workloadConfig) {
+  public YardstickTask(BenchmarkDriver benchmark, WorkloadConfig workloadConfig, String outputDir) {
     this.benchmark = benchmark;
     this.workloadConfig = workloadConfig;
+    this.outputDir = outputDir;
   }
 
   @Override
@@ -75,7 +77,7 @@ public class YardstickTask implements Task {
 
       @Override
       public String outputFolder() {
-        return "output";
+        return outputDir;
       }
     };
     cfg.output(System.out);

--- a/harness/src/main/java/org/apache/geode/perftest/yardstick/YardstickTask.java
+++ b/harness/src/main/java/org/apache/geode/perftest/yardstick/YardstickTask.java
@@ -42,13 +42,11 @@ import org.apache.geode.perftest.WorkloadConfig;
  */
 public class YardstickTask implements Task {
   private final BenchmarkDriver benchmark;
-  private final String outputDir;
   private WorkloadConfig workloadConfig;
 
-  public YardstickTask(BenchmarkDriver benchmark, WorkloadConfig workloadConfig, String outputDir) {
+  public YardstickTask(BenchmarkDriver benchmark, WorkloadConfig workloadConfig) {
     this.benchmark = benchmark;
     this.workloadConfig = workloadConfig;
-    this.outputDir = outputDir;
   }
 
   @Override
@@ -77,7 +75,7 @@ public class YardstickTask implements Task {
 
       @Override
       public String outputFolder() {
-        return outputDir;
+        return context.getOutputDir().getAbsolutePath();
       }
     };
     cfg.output(System.out);

--- a/harness/src/test/java/org/apache/geode/perftest/TestRunnerIntegrationTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/TestRunnerIntegrationTest.java
@@ -24,12 +24,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -51,7 +48,7 @@ public class TestRunnerIntegrationTest {
   @Before
   public void setup() throws IOException {
     outputDir = temporaryFolder.newFolder();
-    runner = new DefaultTestRunner(new LocalInfrastructureFactory(), new RemoteJVMFactory(),
+    runner = new DefaultTestRunner(new RemoteJVMFactory(new LocalInfrastructureFactory()),
         outputDir);
   }
 
@@ -77,7 +74,7 @@ public class TestRunnerIntegrationTest {
     assertTrue(expectedBenchmarkDir.exists());
 
     //Node directory name is the role + a number
-    File expectedNodeDir = new File(expectedBenchmarkDir, "all0");
+    File expectedNodeDir = new File(expectedBenchmarkDir, "all-0");
     assertTrue(expectedNodeDir.exists());
 
     //We expect the node directory to have benchmark results

--- a/harness/src/test/java/org/apache/geode/perftest/TestRunnerIntegrationTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/TestRunnerIntegrationTest.java
@@ -17,23 +17,78 @@
 
 package org.apache.geode.perftest;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.geode.perftest.benchmarks.EmptyBenchmark;
 import org.apache.geode.perftest.infrastructure.local.LocalInfrastructureFactory;
 import org.apache.geode.perftest.jvms.RemoteJVMFactory;
 import org.apache.geode.perftest.runner.DefaultTestRunner;
+import org.apache.geode.perftest.yardstick.analysis.YardstickThroughputSensorParser;
 
 public class TestRunnerIntegrationTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private TestRunner runner;
+  private File outputDir;
+  public static final String SAMPLE_BENCHMARK = "SampleBenchmark";
+
+  @Before
+  public void setup() throws IOException {
+    outputDir = temporaryFolder.newFolder();
+    runner = new DefaultTestRunner(new LocalInfrastructureFactory(), new RemoteJVMFactory(),
+        outputDir);
+  }
 
   @Test
   public void runsBeforeWorkload() throws Exception {
-    TestRunner runner = new DefaultTestRunner(new LocalInfrastructureFactory(), new RemoteJVMFactory());
-
     runner.runTest(testConfig -> {
+      testConfig.name(SAMPLE_BENCHMARK);
       testConfig.role("all", 1);
       testConfig.before(context -> System.out.println("hello"), "all");
+    });
+  }
 
+  @Test
+  public void generatesOutputDirectoryPerBenchmark() throws Exception {
+
+    runner.runTest(testConfig -> {
+      testConfig.name(SAMPLE_BENCHMARK);
+      testConfig.role("all", 1);
+      testConfig.workload(new EmptyBenchmark(), "all");
     });
 
+    File expectedBenchmarkDir = new File(outputDir, SAMPLE_BENCHMARK);
+    assertTrue(expectedBenchmarkDir.exists());
+
+    //Node directory name is the role + a number
+    File expectedNodeDir = new File(expectedBenchmarkDir, "all0");
+    assertTrue(expectedNodeDir.exists());
+
+    //We expect the node directory to have benchmark results
+    Stream<Path>
+        outputFiles = Files.walk(expectedNodeDir.toPath())
+        .filter(nameMatches(YardstickThroughputSensorParser.sensorOutputFile));
+
+    assertEquals(1, outputFiles.count());
+  }
+
+  private Predicate<Path> nameMatches(String sensorOutputFile) {
+    return path -> path.toString().contains(sensorOutputFile);
   }
 }

--- a/harness/src/test/java/org/apache/geode/perftest/TestRunnerJUnitTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/TestRunnerJUnitTest.java
@@ -46,16 +46,12 @@ public class TestRunnerJUnitTest {
   @Test
   public void testRunnerRunsBeforeAndAfterTasks() throws Exception {
 
-    InfrastructureFactory infrastructureFactory = mock(InfrastructureFactory.class);
-    Infrastructure infrastructure = mock(Infrastructure.class);
     RemoteJVMFactory remoteJvmFactory = mock(RemoteJVMFactory.class);
 
-    when(infrastructureFactory.create(anyInt())).thenReturn(infrastructure);
-
     RemoteJVMs remoteJVMs = mock(RemoteJVMs.class);
-    when(remoteJvmFactory.launch(eq(infrastructure), any())).thenReturn(remoteJVMs);
+    when(remoteJvmFactory.launch(any())).thenReturn(remoteJVMs);
 
-    TestRunner runner = new DefaultTestRunner(infrastructureFactory, remoteJvmFactory,
+    TestRunner runner = new DefaultTestRunner(remoteJvmFactory,
         folder.newFolder());
 
     Task before = mock(Task.class);

--- a/harness/src/test/java/org/apache/geode/perftest/TestRunnerJUnitTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/TestRunnerJUnitTest.java
@@ -25,7 +25,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.InOrder;
 
 import org.apache.geode.perftest.infrastructure.InfrastructureFactory;
@@ -35,6 +39,9 @@ import org.apache.geode.perftest.jvms.RemoteJVMs;
 import org.apache.geode.perftest.runner.DefaultTestRunner;
 
 public class TestRunnerJUnitTest {
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
 
   @Test
   public void testRunnerRunsBeforeAndAfterTasks() throws Exception {
@@ -48,12 +55,14 @@ public class TestRunnerJUnitTest {
     RemoteJVMs remoteJVMs = mock(RemoteJVMs.class);
     when(remoteJvmFactory.launch(eq(infrastructure), any())).thenReturn(remoteJVMs);
 
-    TestRunner runner = new DefaultTestRunner(infrastructureFactory, remoteJvmFactory);
+    TestRunner runner = new DefaultTestRunner(infrastructureFactory, remoteJvmFactory,
+        folder.newFolder());
 
     Task before = mock(Task.class);
     Task after = mock(Task.class);
 
     PerformanceTest test = config -> {
+      config.name("SampleBenchmark");
       config.role("before", 1);
       config.role("workload", 1);
       config.role("after", 1);

--- a/harness/src/test/java/org/apache/geode/perftest/TestRunnersTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/TestRunnersTest.java
@@ -17,18 +17,12 @@
 
 package org.apache.geode.perftest;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 
-import jdk.nashorn.internal.objects.NativeDebug;
-import org.junit.Rule;
 import org.junit.Test;
 
-import org.apache.geode.perftest.infrastructure.InfrastructureFactory;
-import org.apache.geode.perftest.infrastructure.local.LocalInfrastructure;
-import org.apache.geode.perftest.infrastructure.local.LocalInfrastructureFactory;
-import org.apache.geode.perftest.infrastructure.ssh.SshInfrastructure;
 import org.apache.geode.perftest.infrastructure.ssh.SshInfrastructureFactory;
 import org.apache.geode.perftest.runner.DefaultTestRunner;
 
@@ -39,7 +33,7 @@ public class TestRunnersTest {
     DefaultTestRunner runner = (DefaultTestRunner) TestRunners.defaultRunner("localhost,localhost");
 
     SshInfrastructureFactory infrastructureFactory =
-        (SshInfrastructureFactory) runner.getInfrastructureFactory();
+        (SshInfrastructureFactory) runner.getRemoteJvmFactory().getInfrastructureFactory();
 
     assertEquals(Arrays.asList("localhost", "localhost") , infrastructureFactory.getHosts());
   }

--- a/harness/src/test/java/org/apache/geode/perftest/TestRunnersTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/TestRunnersTest.java
@@ -30,7 +30,7 @@ public class TestRunnersTest {
 
   @Test
   public void defaultRunnerShouldParseHosts() {
-    DefaultTestRunner runner = (DefaultTestRunner) TestRunners.defaultRunner("localhost,localhost");
+    DefaultTestRunner runner = (DefaultTestRunner) TestRunners.defaultRunner("localhost,localhost", null);
 
     SshInfrastructureFactory infrastructureFactory =
         (SshInfrastructureFactory) runner.getRemoteJvmFactory().getInfrastructureFactory();
@@ -40,6 +40,6 @@ public class TestRunnersTest {
   
   @Test(expected = IllegalStateException.class)
   public void defaultRunnerShouldFailWithNoHosts() {
-    TestRunners.defaultRunner(null);
+    TestRunners.defaultRunner(null, null);
   }
 }

--- a/harness/src/test/java/org/apache/geode/perftest/benchmarks/EmptyBenchmark.java
+++ b/harness/src/test/java/org/apache/geode/perftest/benchmarks/EmptyBenchmark.java
@@ -15,25 +15,29 @@
  * limitations under the License.
  */
 
-package org.apache.geode.benchmark;
+package org.apache.geode.perftest.benchmarks;
 
-import java.io.File;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.yardstickframework.BenchmarkDriverAdapter;
 
-import org.apache.geode.benchmark.tests.PartitionedPutBenchmark;
-import org.apache.geode.perftest.TestRunners;
+public class EmptyBenchmark extends BenchmarkDriverAdapter implements Serializable {
+  private AtomicInteger invocations = new AtomicInteger();
 
-public class PartitionedPutBenchmarkTest {
+  @Override
+  public boolean test(Map<Object, Object> ctx) throws Exception {
+    invocations.incrementAndGet();
+    return true;
+  }
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  public int getInvocations() {
+    return this.invocations.get();
+  }
 
-  @Test
-  public void benchmarkRunsSuccessfully() throws Exception {
-    TestRunners.minimalRunner(folder.newFolder())
-        .runTest(new PartitionedPutBenchmark()::configure);
+  @Override
+  public void onException(Throwable e) {
+    e.printStackTrace();
   }
 }

--- a/harness/src/test/java/org/apache/geode/perftest/infrastructure/local/LocalInfrastructureTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/infrastructure/local/LocalInfrastructureTest.java
@@ -57,7 +57,7 @@ public class LocalInfrastructureTest {
 
     File expectedDir = new File(nodedir, "lib");
     assertFalse(expectedDir.exists());
-    infra.copyToNodes(Arrays.asList(someFile), "lib");
+    infra.copyToNodes(Arrays.asList(someFile), "lib", true);
     assertTrue(expectedDir.exists());
     assertTrue(new File(expectedDir, someFile.getName()).exists());
 

--- a/harness/src/test/java/org/apache/geode/perftest/infrastructure/ssh/SshInfrastructureTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/infrastructure/ssh/SshInfrastructureTest.java
@@ -70,10 +70,29 @@ public class SshInfrastructureTest {
 
     assertFalse(targetFolder.exists());
 
-    infra.copyToNodes(Arrays.asList(someFile), targetFolder.getPath());
+    infra.copyToNodes(Arrays.asList(someFile), targetFolder.getPath(), false);
 
     assertTrue(targetFolder.exists());
     assertTrue(new File(targetFolder, someFile.getName()).exists());
+  }
+
+  @Test
+  public void copyToNodesCleansDirectory() throws IOException, InterruptedException {
+    SshInfrastructure infra = new SshInfrastructure(HOSTS, USER);
+
+    File someFile = temporaryFolder.newFile();
+    File targetFolder = new File(temporaryFolder.newFolder(), "dest");
+
+    targetFolder.mkdirs();
+    File fileToRemove = new File(targetFolder, "removethis");
+    fileToRemove.createNewFile();
+    assertTrue(fileToRemove.exists());
+
+    infra.copyToNodes(Arrays.asList(someFile), targetFolder.getPath(), true);
+
+    assertTrue(targetFolder.exists());
+    assertTrue(new File(targetFolder, someFile.getName()).exists());
+    assertFalse(fileToRemove.exists());
   }
 
 

--- a/harness/src/test/java/org/apache/geode/perftest/jvms/RemoteJVMFactoryIntegrationTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/jvms/RemoteJVMFactoryIntegrationTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import org.apache.geode.perftest.infrastructure.local.LocalInfrastructure;
+import org.apache.geode.perftest.infrastructure.local.LocalInfrastructureFactory;
 
 public class RemoteJVMFactoryIntegrationTest {
   @Rule
@@ -35,9 +36,9 @@ public class RemoteJVMFactoryIntegrationTest {
 
   @Test
   public void canExecuteCodeOnWorker() throws Exception {
-    RemoteJVMFactory remoteJvmFactory = new RemoteJVMFactory();
+    RemoteJVMFactory remoteJvmFactory = new RemoteJVMFactory(new LocalInfrastructureFactory());
     Map<String, Integer> roles = Collections.singletonMap("worker", 1);
-    try (RemoteJVMs jvms = remoteJvmFactory.launch(new LocalInfrastructure(1), roles)) {
+    try (RemoteJVMs jvms = remoteJvmFactory.launch(roles)) {
       File tempFile = new File(temporaryFolder.newFolder(), "tmpfile").getAbsoluteFile();
       jvms.execute(context -> {
         tempFile.createNewFile();

--- a/harness/src/test/java/org/apache/geode/perftest/jvms/RemoteJVMFactoryTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/jvms/RemoteJVMFactoryTest.java
@@ -41,7 +41,6 @@ import org.apache.geode.perftest.infrastructure.InfrastructureFactory;
 import org.apache.geode.perftest.jvms.classpath.ClassPathCopier;
 import org.apache.geode.perftest.jvms.rmi.Controller;
 import org.apache.geode.perftest.jvms.rmi.ControllerFactory;
-import org.apache.geode.perftest.runner.SharedContext;
 
 public class RemoteJVMFactoryTest {
 

--- a/harness/src/test/java/org/apache/geode/perftest/jvms/RemoteJVMFactoryTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/jvms/RemoteJVMFactoryTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import org.mockito.InOrder;
 
 import org.apache.geode.perftest.infrastructure.Infrastructure;
+import org.apache.geode.perftest.infrastructure.InfrastructureFactory;
 import org.apache.geode.perftest.jdk.RMI;
 import org.apache.geode.perftest.jvms.classpath.ClassPathCopier;
 import org.apache.geode.perftest.jvms.rmi.Controller;
@@ -45,11 +46,11 @@ import org.apache.geode.perftest.jvms.rmi.ControllerFactory;
 public class RemoteJVMFactoryTest {
 
   private JVMLauncher jvmLauncher;
-  private RMI rmi;
   private ClassPathCopier classPathCopier;
   private RemoteJVMFactory factory;
   private Controller controller;
   private ControllerFactory controllerFactory;
+  private Infrastructure infra;
 
   @Before
   public void setUp() throws AlreadyBoundException, RemoteException {
@@ -58,13 +59,14 @@ public class RemoteJVMFactoryTest {
     controller = mock(Controller.class);
     controllerFactory = mock(ControllerFactory.class);
     when(controllerFactory.createController(anyInt())).thenReturn(controller);
-    factory = new RemoteJVMFactory(jvmLauncher, rmi, classPathCopier, controllerFactory);
+    infra = mock(Infrastructure.class);
+    InfrastructureFactory infraFactory = nodes -> infra;
+    factory = new RemoteJVMFactory(infraFactory, jvmLauncher, classPathCopier, controllerFactory);
   }
 
   @Test
   public void launchMethodCreatesControllerAndLaunchesNodes() throws Exception {
     Map<String, Integer> roles = Collections.singletonMap("role", 2);
-    Infrastructure infra = mock(Infrastructure.class);
 
     Infrastructure.Node node1 = mock(Infrastructure.Node.class);
     Infrastructure.Node node2 = mock(Infrastructure.Node.class);
@@ -73,7 +75,7 @@ public class RemoteJVMFactoryTest {
 
     when(controller.waitForWorkers(anyInt(), any())).thenReturn(true);
 
-    factory.launch(infra, roles);
+    factory.launch(roles);
 
     InOrder inOrder = inOrder(controller, controllerFactory, jvmLauncher, classPathCopier, infra);
 

--- a/harness/src/test/java/org/apache/geode/perftest/jvms/RemoteJVMFactoryTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/jvms/RemoteJVMFactoryTest.java
@@ -38,10 +38,10 @@ import org.mockito.InOrder;
 
 import org.apache.geode.perftest.infrastructure.Infrastructure;
 import org.apache.geode.perftest.infrastructure.InfrastructureFactory;
-import org.apache.geode.perftest.jdk.RMI;
 import org.apache.geode.perftest.jvms.classpath.ClassPathCopier;
 import org.apache.geode.perftest.jvms.rmi.Controller;
 import org.apache.geode.perftest.jvms.rmi.ControllerFactory;
+import org.apache.geode.perftest.runner.SharedContext;
 
 public class RemoteJVMFactoryTest {
 
@@ -58,7 +58,7 @@ public class RemoteJVMFactoryTest {
     jvmLauncher = mock(JVMLauncher.class);
     controller = mock(Controller.class);
     controllerFactory = mock(ControllerFactory.class);
-    when(controllerFactory.createController(anyInt())).thenReturn(controller);
+    when(controllerFactory.createController(any(), anyInt())).thenReturn(controller);
     infra = mock(Infrastructure.class);
     InfrastructureFactory infraFactory = nodes -> infra;
     factory = new RemoteJVMFactory(infraFactory, jvmLauncher, classPathCopier, controllerFactory);
@@ -79,7 +79,7 @@ public class RemoteJVMFactoryTest {
 
     InOrder inOrder = inOrder(controller, controllerFactory, jvmLauncher, classPathCopier, infra);
 
-    inOrder.verify(controllerFactory).createController(eq(2));
+    inOrder.verify(controllerFactory).createController(any(), eq(2));
     inOrder.verify(jvmLauncher).launchProcesses(eq(infra), anyInt(), any(), any());
     inOrder.verify(controller).waitForWorkers(anyInt(), any());
 

--- a/harness/src/test/java/org/apache/geode/perftest/jvms/RemoteJVMFactoryTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/jvms/RemoteJVMFactoryTest.java
@@ -78,7 +78,7 @@ public class RemoteJVMFactoryTest {
     InOrder inOrder = inOrder(controller, controllerFactory, jvmLauncher, classPathCopier, infra);
 
     inOrder.verify(controllerFactory).createController(eq(2));
-    inOrder.verify(jvmLauncher).launchProcesses(eq(infra), anyInt(), any());
+    inOrder.verify(jvmLauncher).launchProcesses(eq(infra), anyInt(), any(), any());
     inOrder.verify(controller).waitForWorkers(anyInt(), any());
 
 

--- a/harness/src/test/java/org/apache/geode/perftest/jvms/rmi/ChildJVMTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/jvms/rmi/ChildJVMTest.java
@@ -24,12 +24,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.rmi.NotBoundException;
 import java.rmi.RemoteException;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import org.apache.geode.perftest.jdk.RMI;
 import org.apache.geode.perftest.jdk.SystemInterface;
@@ -37,16 +41,18 @@ import org.apache.geode.perftest.jvms.RemoteJVMFactory;
 
 public class ChildJVMTest {
 
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private RMI rmi;
   private ChildJVM jvm;
   private SystemInterface system;
   private Controller controller;
 
   @Before
-  public void setUp() throws RemoteException, NotBoundException, MalformedURLException {
+  public void setUp() throws IOException, NotBoundException {
     system = mock(SystemInterface.class);
     rmi = mock(RMI.class);
-    jvm = new ChildJVM(rmi, system, 1);
+    jvm = new ChildJVM(rmi, system, 1, temporaryFolder.newFolder());
 
     controller = mock(Controller.class);
     when(rmi.lookup(any())).thenReturn(controller);

--- a/harness/src/test/java/org/apache/geode/perftest/runner/SharedContextTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/runner/SharedContextTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.apache.geode.perftest.infrastructure.Infrastructure;
 import org.apache.geode.perftest.jvms.JVMMapping;
 
-public class DefaultTestContextTest {
+public class SharedContextTest {
 
   @Test
   public void getHostsForRoleShouldReturnCorrectList() throws UnknownHostException {
@@ -47,7 +47,7 @@ public class DefaultTestContextTest {
     when(node2.getAddress()).thenReturn(host2);
     JVMMapping mapping2 = new JVMMapping(node2, "role", 2);
 
-    DefaultTestContext context = new DefaultTestContext(Arrays.asList(mapping1, mapping2));
+    SharedContext context = new SharedContext(Arrays.asList(mapping1, mapping2));
 
     Set<InetAddress> hosts = context.getHostsForRole("role");
 

--- a/harness/src/test/java/org/apache/geode/perftest/yardstick/YardstickTaskTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/yardstick/YardstickTaskTest.java
@@ -17,31 +17,29 @@
 
 package org.apache.geode.perftest.yardstick;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
-import org.yardstickframework.BenchmarkDriverAdapter;
+import org.junit.rules.TemporaryFolder;
 
 import org.apache.geode.perftest.Task;
 import org.apache.geode.perftest.WorkloadConfig;
+import org.apache.geode.perftest.benchmarks.EmptyBenchmark;
 
 public class YardstickTaskTest {
+
+  @Rule
+  public final TemporaryFolder folder = new TemporaryFolder();
 
   @Test
   public void testExecuteBenchmark() throws Exception {
     EmptyBenchmark benchmark = new EmptyBenchmark();
     WorkloadConfig workloadConfig = new WorkloadConfig();
     workloadConfig.threads(1);
-    Task task = new YardstickTask(benchmark, workloadConfig);
+    Task task = new YardstickTask(benchmark, workloadConfig, folder.newFolder().getAbsolutePath());
     task.run(null);
 
-    Assert.assertTrue(1 <= benchmark.invocations.get());
+    Assert.assertTrue(1 <= benchmark.getInvocations());
 
     //TODO -verify probes are shutdown
     //TODO -verify benchmark is shutdown
@@ -49,18 +47,4 @@ public class YardstickTaskTest {
 
   }
 
-  private static class EmptyBenchmark extends BenchmarkDriverAdapter {
-    private AtomicInteger invocations = new AtomicInteger();
-
-    @Override
-    public boolean test(Map<Object, Object> ctx) throws Exception {
-      invocations.incrementAndGet();
-      return true;
-    }
-
-    @Override
-    public void onException(Throwable e) {
-      e.printStackTrace();
-    }
-  }
 }

--- a/harness/src/test/java/org/apache/geode/perftest/yardstick/YardstickTaskTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/yardstick/YardstickTaskTest.java
@@ -17,14 +17,21 @@
 
 package org.apache.geode.perftest.yardstick;
 
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import org.apache.geode.perftest.Task;
+import org.apache.geode.perftest.TestContext;
 import org.apache.geode.perftest.WorkloadConfig;
 import org.apache.geode.perftest.benchmarks.EmptyBenchmark;
+import org.apache.geode.perftest.runner.DefaultTestContext;
 
 public class YardstickTaskTest {
 
@@ -36,15 +43,17 @@ public class YardstickTaskTest {
     EmptyBenchmark benchmark = new EmptyBenchmark();
     WorkloadConfig workloadConfig = new WorkloadConfig();
     workloadConfig.threads(1);
-    Task task = new YardstickTask(benchmark, workloadConfig, folder.newFolder().getAbsolutePath());
-    task.run(null);
+    Task task = new YardstickTask(benchmark, workloadConfig);
+    File outputDir = folder.newFolder();
+    TestContext context = new DefaultTestContext(null, outputDir);
+    task.run(context);
 
-    Assert.assertTrue(1 <= benchmark.getInvocations());
+    assertTrue(1 <= benchmark.getInvocations());
+
+    assertTrue(Files.walk(outputDir.toPath()).findFirst().isPresent());
 
     //TODO -verify probes are shutdown
     //TODO -verify benchmark is shutdown
-    //TODO - pass in probes to yardstick util, turn it into a real class
-
   }
 
 }


### PR DESCRIPTION
Cleaning up the output of geode benchmarks by making sure that all directories are cleaned after the run, and configuring the per node and final output directory names.