### PR TITLE
Change project name to geode-benchmarks.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-rootProject.name = 'play-perf-framework'
+rootProject.name = 'geode-benchmarks'
 
 include 'harness'
 include 'geode-benchmarks'


### PR DESCRIPTION
I'm not sure if this is the best name for the project, but it makes more sense than what it was.