### PR TITLE
GEODE-6145: Allow multiple results for a single probe analyzer

### DIFF
--- a/harness/src/main/java/org/apache/geode/perftest/analysis/ProbeResultParser.java
+++ b/harness/src/main/java/org/apache/geode/perftest/analysis/ProbeResultParser.java
@@ -16,8 +16,10 @@ package org.apache.geode.perftest.analysis;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 public interface ProbeResultParser {
+
   // Given a output directory for a benchmark, parse out the data for the desired probe. Note that
   // this method may be passed several csv files for a run and is expected to appropriately
   // aggregate the result of interest.
@@ -26,9 +28,16 @@ public interface ProbeResultParser {
   // Reset the parser to a clean state where parseResults can be called again
   void reset();
 
-  // Get a single float value summarizing the data for the probe.
-  double getProbeResult();
+  // Get the {description, value} pairs for the probe
+  List<ResultData> getProbeResults();
 
-  // Get a text description of what the probe result is depicting
-  String getResultDescription();
+  class ResultData {
+    public String description;
+    public double value;
+
+    public ResultData(String description, double value) {
+      this.description = description;
+      this.value = value;
+    }
+  }
 }

--- a/harness/src/main/java/org/apache/geode/perftest/yardstick/analysis/YardstickHdrHistogramParser.java
+++ b/harness/src/main/java/org/apache/geode/perftest/yardstick/analysis/YardstickHdrHistogramParser.java
@@ -17,6 +17,8 @@ package org.apache.geode.perftest.yardstick.analysis;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.HdrHistogram.Histogram;
 import org.HdrHistogram.HistogramLogReader;
@@ -31,7 +33,6 @@ import org.apache.geode.perftest.yardstick.hdrhistogram.HdrHistogramWriter;
  */
 public class YardstickHdrHistogramParser implements ProbeResultParser {
   public static final String sensorOutputFile = HdrHistogramWriter.FILE_NAME;
-  public static final String probeResultDescription = "HDR 99th percentile latency";
 
   public Histogram histogram = null;
 
@@ -55,13 +56,15 @@ public class YardstickHdrHistogramParser implements ProbeResultParser {
   }
 
   @Override
-  // Default probe result is the 99th percentile latency for the benchmark
-  public double getProbeResult() {
-    return histogram.getValueAtPercentile(99);
-  }
+  public List<ResultData> getProbeResults() {
+    List<ResultData> results = new ArrayList<>(3);
+    results.add(new ResultData("median latency", histogram.getValueAtPercentile(50)));
+    results.add(new ResultData("90th percentile latency", histogram.getValueAtPercentile(90)));
+    results.add(new ResultData("99th percentile latency", histogram.getValueAtPercentile(99)));
+    results.add(new ResultData("99.9th percentile latency", histogram.getValueAtPercentile(99.9)));
+    results.add(new ResultData("average latency", histogram.getMean()));
+    results.add(new ResultData("latency standard deviation", histogram.getStdDeviation()));
 
-  @Override
-  public String getResultDescription() {
-    return probeResultDescription;
+    return results;
   }
 }

--- a/harness/src/main/java/org/apache/geode/perftest/yardstick/analysis/YardstickPercentileSensorParser.java
+++ b/harness/src/main/java/org/apache/geode/perftest/yardstick/analysis/YardstickPercentileSensorParser.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.yardstickframework.probes.PercentileProbe;
 
@@ -32,7 +33,7 @@ import org.apache.geode.perftest.analysis.ProbeResultParser;
  */
 public class YardstickPercentileSensorParser implements ProbeResultParser {
   public static final String sensorOutputFile = "PercentileProbe.csv";
-  public static final String probeResultDescription = "99th percentile latency";
+  public static final String probeResultDescription = "YS 99th percentile latency";
 
   private class SensorBucket {
     public int latencyBucket;
@@ -72,17 +73,6 @@ public class YardstickPercentileSensorParser implements ProbeResultParser {
   @Override
   public void reset() {
     buckets = new ArrayList<>();
-  }
-
-  @Override
-  // Default probe result is the 99th percentile latency for the benchmark
-  public double getProbeResult() {
-    return getPercentile(99);
-  }
-
-  @Override
-  public String getResultDescription() {
-    return probeResultDescription;
   }
 
   private void normalizeBuckets() {
@@ -130,5 +120,13 @@ public class YardstickPercentileSensorParser implements ProbeResultParser {
         1.0 - ((accumulator - targetPercent) / targetBucket.bucketPercentage);
 
     return targetBucket.latencyBucket + bucketSize * percentileLocationInTargetBucket;
+  }
+
+  @Override
+  public List<ResultData> getProbeResults() {
+    List<ResultData> results = new ArrayList<>(1);
+    results.add(new ResultData(probeResultDescription, getPercentile(99)));
+
+    return results;
   }
 }

--- a/harness/src/main/java/org/apache/geode/perftest/yardstick/analysis/YardstickThroughputSensorParser.java
+++ b/harness/src/main/java/org/apache/geode/perftest/yardstick/analysis/YardstickThroughputSensorParser.java
@@ -56,13 +56,11 @@ public class YardstickThroughputSensorParser implements ProbeResultParser {
   }
 
   @Override
-  public double getProbeResult() {
-    return getAverageThroughput();
-  }
+  public List<ResultData> getProbeResults() {
+    List<ResultData> results = new ArrayList<>(1);
+    results.add(new ResultData(probeResultDescription, getAverageThroughput()));
 
-  @Override
-  public String getResultDescription() {
-    return probeResultDescription;
+    return results;
   }
 
   public double getAverageThroughput() {

--- a/harness/src/test/java/org/apache/geode/perftest/analysis/BenchmarkRunAnalyzerTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/analysis/BenchmarkRunAnalyzerTest.java
@@ -81,7 +81,7 @@ public class BenchmarkRunAnalyzerTest {
 
     StringWriter writer = new StringWriter();
 
-    BenchmarkRunResult results = harvester.analyzeTestRun(testFolder, baseFolder);
+    BenchmarkRunResult results = harvester.analyzeTestRun(baseFolder, testFolder);
 
     BenchmarkRunResult expectedBenchmarkResult = new BenchmarkRunResult();
     BenchmarkRunResult.BenchmarkResult resultA = expectedBenchmarkResult.addBenchmark("BenchmarkA");


### PR DESCRIPTION
This change modifies the ProbeResultParser interface to return a list of
ResultData objects.  It takes advantage of this new functionality to return
6 results from the HDRHistogramParser (median latency, 90, 99, 99.9 percentile
latencies, average latency, and latency standard deviation).  This is probably
too noisy for the long run, but could prove useful as we evaluate different
platforms.

This change also changes the BenchmarkRunAnalyzer (invoked via gradlew
analyzeRun) to take the baseline directory as its first argument.