### PR TITLE
Convert to sole tenant style cluster.

### DIFF
--- a/infrastructure/google_cloud/destroy_cluster.sh
+++ b/infrastructure/google_cloud/destroy_cluster.sh
@@ -19,6 +19,10 @@
 
 TAG=${1}
 PREFIX="geode-performance-${TAG}"
+NODE_TEMPLATE="${PREFIX}-node-template"
+NODE_GROUP="${PREFIX}-node-group"
 
 gcloud compute instance-groups managed delete ${PREFIX} --quiet
 gcloud compute instance-templates delete ${PREFIX}-template --quiet
+gcloud compute sole-tenancy node-groups delete ${NODE_GROUP}
+gcloud compute sole-tenancy node-templates delete ${NODE_TEMPLATE}

--- a/infrastructure/google_cloud/launch_cluster.sh
+++ b/infrastructure/google_cloud/launch_cluster.sh
@@ -24,16 +24,21 @@ COUNT=${2}
 SUBNET=${3}
 IMAGE_FAMILY="geode-performance"
 PREFIX="geode-performance-${TAG}"
-INSTANCE_TYPE=n1-standard-16
+NODE_TEMPLATE="${PREFIX}-node-template"
+NODE_GROUP="${PREFIX}-node-group"
+INSTANCE_TYPE=n1-highmem-96
 
 KEY_FILE=/tmp/id_${TAG}
 
 ssh-keygen -b 2048 -t rsa -f $KEY_FILE -q -N ""
 
+gcloud compute sole-tenancy node-templates create ${NODE_TEMPLATE} --node-type=n1-node-96-624
+gcloud compute sole-tenancy node-groups create ${NODE_GROUP} --node-template=${NODE_TEMPLATE} --target-size=${COUNT}
 
 gcloud compute instance-templates create ${PREFIX}-template \
   --machine-type=${INSTANCE_TYPE} \
   --subnet=${SUBNET}  \
+  --node-group="${NODE_GROUP}" \
   --image-family=${IMAGE_FAMILY} \
   --boot-disk-size=50GB \
   --boot-disk-type=pd-ssd


### PR DESCRIPTION
This launches the cluster using single-tenant nodes instead of random instances.