### PR TITLE
GEODE-6172: Configure geode properties for benchmarks

### DIFF
--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/GeodeProperties.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/GeodeProperties.java
@@ -34,8 +34,8 @@ public class GeodeProperties {
     properties.setProperty(ConfigurationProperties.ARCHIVE_DISK_SPACE_LIMIT, "150");
     properties.setProperty(ConfigurationProperties.ARCHIVE_FILE_SIZE_LIMIT, "10");
     properties.setProperty(ConfigurationProperties.DISTRIBUTED_SYSTEM_ID, "0");
-    properties.setProperty(ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION, "true");
-    properties.setProperty(ConfigurationProperties.USE_CLUSTER_CONFIGURATION, "true");
+    properties.setProperty(ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION, "false");
+    properties.setProperty(ConfigurationProperties.USE_CLUSTER_CONFIGURATION, "false");
     return properties;
   }
 

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/GeodeProperties.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/GeodeProperties.java
@@ -19,24 +19,39 @@ import java.util.Properties;
 import org.apache.geode.distributed.ConfigurationProperties;
 
 public class GeodeProperties {
+
   public static Properties serverProperties() {
-    Properties serverProperties = new Properties();
+    Properties properties = new Properties();
 
-
-    serverProperties.setProperty(ConfigurationProperties.CONSERVE_SOCKETS, "false");
-    serverProperties.setProperty(ConfigurationProperties.ENABLE_TIME_STATISTICS, "true");
-    serverProperties.setProperty(ConfigurationProperties.LOCATOR_WAIT_TIME, "120");
-    serverProperties.setProperty(ConfigurationProperties.LOG_DISK_SPACE_LIMIT, "100");
-    serverProperties.setProperty(ConfigurationProperties.LOG_FILE_SIZE_LIMIT, "10");
-    serverProperties.setProperty(ConfigurationProperties.LOG_LEVEL, "config");
-    serverProperties.setProperty(ConfigurationProperties.REMOVE_UNRESPONSIVE_CLIENT, "true");
-    serverProperties.setProperty(ConfigurationProperties.STATISTIC_SAMPLING_ENABLED, "true");
-    serverProperties.setProperty(ConfigurationProperties.ARCHIVE_DISK_SPACE_LIMIT, "150");
-    serverProperties.setProperty(ConfigurationProperties.ARCHIVE_FILE_SIZE_LIMIT, "10");
-    serverProperties.setProperty(ConfigurationProperties.DISTRIBUTED_SYSTEM_ID, "0");
-    serverProperties.setProperty(ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION, "true");
-    serverProperties.setProperty(ConfigurationProperties.USE_CLUSTER_CONFIGURATION, "true");
-    return serverProperties;
+    properties.setProperty(ConfigurationProperties.CONSERVE_SOCKETS, "false");
+    properties.setProperty(ConfigurationProperties.ENABLE_TIME_STATISTICS, "true");
+    properties.setProperty(ConfigurationProperties.LOCATOR_WAIT_TIME, "120");
+    properties.setProperty(ConfigurationProperties.LOG_DISK_SPACE_LIMIT, "100");
+    properties.setProperty(ConfigurationProperties.LOG_FILE_SIZE_LIMIT, "10");
+    properties.setProperty(ConfigurationProperties.LOG_LEVEL, "config");
+    properties.setProperty(ConfigurationProperties.REMOVE_UNRESPONSIVE_CLIENT, "true");
+    properties.setProperty(ConfigurationProperties.STATISTIC_SAMPLING_ENABLED, "true");
+    properties.setProperty(ConfigurationProperties.ARCHIVE_DISK_SPACE_LIMIT, "150");
+    properties.setProperty(ConfigurationProperties.ARCHIVE_FILE_SIZE_LIMIT, "10");
+    properties.setProperty(ConfigurationProperties.DISTRIBUTED_SYSTEM_ID, "0");
+    properties.setProperty(ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION, "true");
+    properties.setProperty(ConfigurationProperties.USE_CLUSTER_CONFIGURATION, "true");
+    return properties;
   }
+
+  public static Properties locatorProperties() {
+    // Locator properties are the same as the server properties right now
+    return serverProperties();
+  }
+
+  public static Properties clientProperties() {
+    Properties properties = new Properties();
+    properties.setProperty(ConfigurationProperties.ENABLE_TIME_STATISTICS, "true");
+    properties.setProperty(ConfigurationProperties.LOG_LEVEL, "config");
+    properties.setProperty(ConfigurationProperties.STATISTIC_SAMPLING_ENABLED, "true");
+    return properties;
+
+  }
+
 
 }

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/GeodeProperties.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/GeodeProperties.java
@@ -1,0 +1,28 @@
+package org.apache.geode.benchmark.parameters;
+
+import java.util.Properties;
+
+import org.apache.geode.distributed.ConfigurationProperties;
+
+public class GeodeProperties {
+  public static Properties serverProperties() {
+    Properties serverProperties = new Properties();
+
+
+    serverProperties.setProperty(ConfigurationProperties.CONSERVE_SOCKETS, "false");
+    serverProperties.setProperty(ConfigurationProperties.ENABLE_TIME_STATISTICS, "true");
+    serverProperties.setProperty(ConfigurationProperties.LOCATOR_WAIT_TIME, "120");
+    serverProperties.setProperty(ConfigurationProperties.LOG_DISK_SPACE_LIMIT, "100");
+    serverProperties.setProperty(ConfigurationProperties.LOG_FILE_SIZE_LIMIT, "10");
+    serverProperties.setProperty(ConfigurationProperties.LOG_LEVEL, "config");
+    serverProperties.setProperty(ConfigurationProperties.REMOVE_UNRESPONSIVE_CLIENT, "true");
+    serverProperties.setProperty(ConfigurationProperties.STATISTIC_SAMPLING_ENABLED, "true");
+    serverProperties.setProperty(ConfigurationProperties.ARCHIVE_DISK_SPACE_LIMIT, "150");
+    serverProperties.setProperty(ConfigurationProperties.ARCHIVE_FILE_SIZE_LIMIT, "10");
+    serverProperties.setProperty(ConfigurationProperties.DISTRIBUTED_SYSTEM_ID, "0");
+    serverProperties.setProperty(ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION, "true");
+    serverProperties.setProperty(ConfigurationProperties.USE_CLUSTER_CONFIGURATION, "true");
+    return serverProperties;
+  }
+
+}

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/GeodeProperties.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/GeodeProperties.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.geode.benchmark.parameters;
 
 import java.util.Properties;

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/JVMParameters.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/JVMParameters.java
@@ -12,7 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.benchmark.tests.parameters;
+package org.apache.geode.benchmark.parameters;
 
 public class JVMParameters {
   public static final String[] JVM_ARGS = new String[] {

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartClient.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartClient.java
@@ -20,6 +20,7 @@ package org.apache.geode.benchmark.tasks;
 import java.io.File;
 import java.net.InetAddress;
 
+import org.apache.geode.benchmark.parameters.GeodeProperties;
 import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.distributed.ConfigurationProperties;
@@ -43,9 +44,8 @@ public class StartClient implements Task {
 
     String statsFile = new File(context.getOutputDir(), "stats.gfs").getAbsolutePath();
 
-    ClientCache clientCache = new ClientCacheFactory()
+    ClientCache clientCache = new ClientCacheFactory(GeodeProperties.clientProperties())
         .addPoolLocator(locator.getHostAddress(), locatorPort)
-        .set(ConfigurationProperties.STATISTIC_SAMPLING_ENABLED, "true")
         .set(ConfigurationProperties.STATISTIC_ARCHIVE_FILE, statsFile)
         .create();
 

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartLocator.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartLocator.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.net.InetAddress;
 import java.util.Properties;
 
+import org.apache.geode.benchmark.parameters.GeodeProperties;
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.perftest.Task;
@@ -38,13 +39,10 @@ public class StartLocator implements Task {
 
   @Override
   public void run(TestContext context) throws Exception {
-    Properties properties = new Properties();
+    Properties properties = GeodeProperties.serverProperties();
 
     String statsFile = new File(context.getOutputDir(), "stats.gfs").getAbsolutePath();
-    properties.setProperty(ConfigurationProperties.STATISTIC_SAMPLING_ENABLED, "true");
     properties.setProperty(ConfigurationProperties.STATISTIC_ARCHIVE_FILE, statsFile);
-    properties.setProperty(ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION, "false");
-    properties.setProperty(ConfigurationProperties.USE_CLUSTER_CONFIGURATION, "false");
 
     properties.setProperty(ConfigurationProperties.NAME, "locator-" + InetAddress.getLocalHost());
     Locator.startLocatorAndDS(locatorPort, null, properties);

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartLocator.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartLocator.java
@@ -39,7 +39,7 @@ public class StartLocator implements Task {
 
   @Override
   public void run(TestContext context) throws Exception {
-    Properties properties = GeodeProperties.serverProperties();
+    Properties properties = GeodeProperties.locatorProperties();
 
     String statsFile = new File(context.getOutputDir(), "stats.gfs").getAbsolutePath();
     properties.setProperty(ConfigurationProperties.STATISTIC_ARCHIVE_FILE, statsFile);

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartServer.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartServer.java
@@ -20,6 +20,7 @@ package org.apache.geode.benchmark.tasks;
 import java.io.File;
 import java.net.InetAddress;
 
+import org.apache.geode.benchmark.parameters.GeodeProperties;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.server.CacheServer;
@@ -43,16 +44,14 @@ public class StartServer implements Task {
 
     String locatorString = LocatorUtil.getLocatorString(context, locatorPort);
     String statsFile = new File(context.getOutputDir(), "stats.gfs").getAbsolutePath();
-    Cache cache = new CacheFactory()
+    Cache cache = new CacheFactory(GeodeProperties.serverProperties())
         .set(ConfigurationProperties.LOCATORS, locatorString)
         .set(ConfigurationProperties.NAME,
             "server-" + context.getJvmID() + "-" + InetAddress.getLocalHost())
-        .set(ConfigurationProperties.STATISTIC_SAMPLING_ENABLED, "true")
         .set(ConfigurationProperties.STATISTIC_ARCHIVE_FILE, statsFile)
-        .set(ConfigurationProperties.USE_CLUSTER_CONFIGURATION, "false")
         .create();
 
-    CacheServer cacheServer = ((Cache) cache).addCacheServer();
+    CacheServer cacheServer = cache.addCacheServer();
     cacheServer.setPort(0);
     cacheServer.start();
     context.setAttribute("SERVER_CACHE", cache);

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedGetBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedGetBenchmark.java
@@ -18,8 +18,8 @@
 package org.apache.geode.benchmark.tests;
 
 
-import static org.apache.geode.benchmark.tests.util.ClientServerTopology.Roles.CLIENT;
-import static org.apache.geode.benchmark.tests.util.ClientServerTopology.Roles.SERVER;
+import static org.apache.geode.benchmark.topology.ClientServerTopology.Roles.CLIENT;
+import static org.apache.geode.benchmark.topology.ClientServerTopology.Roles.SERVER;
 
 import org.junit.Test;
 
@@ -27,7 +27,7 @@ import org.apache.geode.benchmark.tasks.CreateClientProxyRegion;
 import org.apache.geode.benchmark.tasks.CreatePartitionedRegion;
 import org.apache.geode.benchmark.tasks.GetTask;
 import org.apache.geode.benchmark.tasks.PrePopulateRegion;
-import org.apache.geode.benchmark.tests.util.ClientServerTopology;
+import org.apache.geode.benchmark.topology.ClientServerTopology;
 import org.apache.geode.perftest.PerformanceTest;
 import org.apache.geode.perftest.TestConfig;
 import org.apache.geode.perftest.TestRunners;

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedPutBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedPutBenchmark.java
@@ -17,8 +17,8 @@
 
 package org.apache.geode.benchmark.tests;
 
-import static org.apache.geode.benchmark.tests.util.ClientServerTopology.Roles.CLIENT;
-import static org.apache.geode.benchmark.tests.util.ClientServerTopology.Roles.SERVER;
+import static org.apache.geode.benchmark.topology.ClientServerTopology.Roles.CLIENT;
+import static org.apache.geode.benchmark.topology.ClientServerTopology.Roles.SERVER;
 
 import org.junit.Test;
 
@@ -26,7 +26,7 @@ import org.apache.geode.benchmark.tasks.CreateClientProxyRegion;
 import org.apache.geode.benchmark.tasks.CreatePartitionedRegion;
 import org.apache.geode.benchmark.tasks.PrePopulateRegion;
 import org.apache.geode.benchmark.tasks.PutTask;
-import org.apache.geode.benchmark.tests.util.ClientServerTopology;
+import org.apache.geode.benchmark.topology.ClientServerTopology;
 import org.apache.geode.perftest.PerformanceTest;
 import org.apache.geode.perftest.TestConfig;
 import org.apache.geode.perftest.TestRunners;

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/ReplicatedGetBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/ReplicatedGetBenchmark.java
@@ -18,8 +18,8 @@
 package org.apache.geode.benchmark.tests;
 
 
-import static org.apache.geode.benchmark.tests.util.ClientServerTopology.Roles.CLIENT;
-import static org.apache.geode.benchmark.tests.util.ClientServerTopology.Roles.SERVER;
+import static org.apache.geode.benchmark.topology.ClientServerTopology.Roles.CLIENT;
+import static org.apache.geode.benchmark.topology.ClientServerTopology.Roles.SERVER;
 
 import org.junit.Test;
 
@@ -27,7 +27,7 @@ import org.apache.geode.benchmark.tasks.CreateClientProxyRegion;
 import org.apache.geode.benchmark.tasks.CreateReplicatedRegion;
 import org.apache.geode.benchmark.tasks.GetTask;
 import org.apache.geode.benchmark.tasks.PrePopulateRegion;
-import org.apache.geode.benchmark.tests.util.ClientServerTopology;
+import org.apache.geode.benchmark.topology.ClientServerTopology;
 import org.apache.geode.perftest.PerformanceTest;
 import org.apache.geode.perftest.TestConfig;
 import org.apache.geode.perftest.TestRunners;

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/ReplicatedPutBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/ReplicatedPutBenchmark.java
@@ -17,8 +17,8 @@
 
 package org.apache.geode.benchmark.tests;
 
-import static org.apache.geode.benchmark.tests.util.ClientServerTopology.Roles.CLIENT;
-import static org.apache.geode.benchmark.tests.util.ClientServerTopology.Roles.SERVER;
+import static org.apache.geode.benchmark.topology.ClientServerTopology.Roles.CLIENT;
+import static org.apache.geode.benchmark.topology.ClientServerTopology.Roles.SERVER;
 
 import org.junit.Test;
 
@@ -26,7 +26,7 @@ import org.apache.geode.benchmark.tasks.CreateClientProxyRegion;
 import org.apache.geode.benchmark.tasks.CreateReplicatedRegion;
 import org.apache.geode.benchmark.tasks.PrePopulateRegion;
 import org.apache.geode.benchmark.tasks.PutTask;
-import org.apache.geode.benchmark.tests.util.ClientServerTopology;
+import org.apache.geode.benchmark.topology.ClientServerTopology;
 import org.apache.geode.perftest.PerformanceTest;
 import org.apache.geode.perftest.TestConfig;
 import org.apache.geode.perftest.TestRunners;

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/topology/ClientServerTopology.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/topology/ClientServerTopology.java
@@ -12,12 +12,12 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.benchmark.tests.util;
+package org.apache.geode.benchmark.topology;
 
-import static org.apache.geode.benchmark.tests.parameters.JVMParameters.JVM_ARGS;
-import static org.apache.geode.benchmark.tests.util.ClientServerTopology.Roles.CLIENT;
-import static org.apache.geode.benchmark.tests.util.ClientServerTopology.Roles.LOCATOR;
-import static org.apache.geode.benchmark.tests.util.ClientServerTopology.Roles.SERVER;
+import static org.apache.geode.benchmark.parameters.JVMParameters.JVM_ARGS;
+import static org.apache.geode.benchmark.topology.ClientServerTopology.Roles.CLIENT;
+import static org.apache.geode.benchmark.topology.ClientServerTopology.Roles.LOCATOR;
+import static org.apache.geode.benchmark.topology.ClientServerTopology.Roles.SERVER;
 
 import org.apache.geode.benchmark.tasks.StartClient;
 import org.apache.geode.benchmark.tasks.StartLocator;


### PR DESCRIPTION
Setting some geode properties on all benchmarks to improve the performance and enable additional statistics.

Refactoring the location of JVMParameters and the util package.