### PR TITLE
GEODE-6148: improve performance of Prepopulate

### DIFF
--- a/geode-benchmarks/build.gradle
+++ b/geode-benchmarks/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     compile(group: 'org.apache.geode', name: 'geode-core', version: geodeVersion)
     compile(group: 'org.slf4j', name: 'slf4j-simple', version: project.'slf4j-simple.version')
     compile(project(':harness'))
+
+    testCompile(group: 'org.mockito', name: 'mockito-all', version: project.'mockito-all.version')
+    testCompile(group: 'org.assertj', name: 'assertj-core', version: project.'assertj-core.version')
 }
 
 test{

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/JVMParameters.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/JVMParameters.java
@@ -38,7 +38,9 @@ public class JVMParameters {
       "-Djava.awt.headless=true",
       "-Dsun.rmi.dgc.server.gcInterval=9223372036854775806",
       "-Dgemfire.OSProcess.ENABLE_OUTPUT_REDIRECTION=true",
-      "-Dgemfire.launcher.registerSignalHandlers=true"
+      "-Dgemfire.launcher.registerSignalHandlers=true",
+      "-Xmx3g",
+      "-Xms3g"
 
   };
 

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/CreatePartitionedRegion.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/CreatePartitionedRegion.java
@@ -28,6 +28,6 @@ public class CreatePartitionedRegion implements Task {
   @Override
   public void run(TestContext context) throws Exception {
     Cache cache = (Cache) context.getAttribute("SERVER_CACHE");
-    cache.createRegionFactory(RegionShortcut.PARTITION).create("region");
+    cache.createRegionFactory(RegionShortcut.PARTITION_REDUNDANT).create("region");
   }
 }

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/PrePopulateRegion.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/PrePopulateRegion.java
@@ -16,10 +16,19 @@
  */
 package org.apache.geode.benchmark.tasks;
 
+import static org.apache.geode.benchmark.topology.ClientServerTopology.Roles.LOCATOR;
+import static org.apache.geode.benchmark.topology.ClientServerTopology.Roles.SERVER;
+
 import java.time.Duration;
 import java.time.Instant;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.LongStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.benchmark.geode.data.Portfolio;
 import org.slf4j.Logger;
@@ -33,6 +42,7 @@ import org.apache.geode.perftest.jvms.RemoteJVMFactory;
 
 public class PrePopulateRegion implements Task {
   long keyRangeToPrepopulate = 10000;
+  private int batchSize = 1000;
   private static final Logger logger = LoggerFactory.getLogger(RemoteJVMFactory.class);
 
   public PrePopulateRegion() {}
@@ -47,21 +57,94 @@ public class PrePopulateRegion implements Task {
    *
    */
   @Override
-  public void run(TestContext context) {
+  public void run(TestContext context) throws InterruptedException {
     Cache serverCache = (Cache) context.getAttribute("SERVER_CACHE");
-    Region region = serverCache.getRegion("region");
+    Region<Long, Portfolio> region = serverCache.getRegion("region");
+    int numLocators = context.getHostsForRole(LOCATOR).size();
+    int numServers = context.getHostsForRole(SERVER).size();
+    int jvmID = context.getJvmID();
+
+    run(region, numLocators, numServers, jvmID);
+
+  }
+
+  void run(Map<Long, Portfolio> region, int numLocators, int numServers, int jvmID)
+      throws InterruptedException {
+    int serverIndex = jvmID - numLocators;
+    long numPutsPerServer = this.keyRangeToPrepopulate / numServers;
+    int numThreads =
+        numPutsPerServer < getBatchSize() ? 1 : Runtime.getRuntime().availableProcessors();
+
+    // calculate non-overlapping key ranges for each server
+    long lowBound = numPutsPerServer * serverIndex;
+    long highBound = numPutsPerServer * (serverIndex + 1);
+    if (serverIndex == (numServers - 1)) {
+      highBound += this.keyRangeToPrepopulate % (serverIndex + 1);
+    }
+
     logger.info("*******************************************");
     logger.info("      Prepopulating the region ");
     logger.info("*******************************************");
     Instant start = Instant.now();
-    LongStream.range(0, keyRangeToPrepopulate).forEach(i -> {
-      long value = ThreadLocalRandom.current().nextLong(0, keyRangeToPrepopulate);
-      region.put(i, new Portfolio(value));
-    });
+
+    ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+    long range = highBound - lowBound;
+    long putsPerThread = range / numThreads;
+
+    for (int i = 0; i < numThreads; i++) {
+      int threadNum = i;
+
+      Runnable putThread = () -> {
+        long low = lowBound + (putsPerThread * threadNum);
+        long high = low + putsPerThread;
+
+        if (threadNum == (numThreads - 1)) {
+          high += range % numThreads;
+        }
+
+        doPuts(region, low, high);
+      };
+
+      futures.add(CompletableFuture.runAsync(putThread, threadPool));
+    }
+
+    futures.forEach(CompletableFuture::join);
+
     Instant finish = Instant.now();
     logger.info("*******************************************");
     logger.info("    Prepopulating the region completed");
     logger.info("    Duration = " + Duration.between(start, finish).toMillis() + "ms.");
     logger.info("*******************************************");
+
+    threadPool.shutdownNow();
+    threadPool.awaitTermination(5, TimeUnit.MINUTES);
+  }
+
+  private void doPuts(Map<Long, Portfolio> region, long lowBound, long highBound) {
+    Map<Long, Portfolio> valueMap = new HashMap<>();
+    for (long putIndex = lowBound; putIndex < highBound; putIndex++) {
+      // build a map of to put to the server
+
+      valueMap.put(putIndex, new Portfolio(putIndex));
+
+      if (putIndex % getBatchSize() == 0) {
+        region.putAll(valueMap);
+        valueMap.clear();
+      }
+    }
+
+    if (!valueMap.isEmpty()) {
+      region.putAll(valueMap);
+    }
+  }
+
+  public int getBatchSize() {
+    return batchSize;
+  }
+
+  public void setBatchSize(int batchSize) {
+    this.batchSize = batchSize;
   }
 }

--- a/geode-benchmarks/src/test/java/org/apache/geode/benchmark/tasks/PrePopulateRegionTest.java
+++ b/geode-benchmarks/src/test/java/org/apache/geode/benchmark/tasks/PrePopulateRegionTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.benchmark.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.geode.benchmark.data.PortfolioPdx;
+
+class PrePopulateRegionTest {
+
+  @Test
+  public void putsEntriesForServer() throws InterruptedException {
+    PrePopulateRegion prePopulateRegion = new PrePopulateRegion(100);
+
+    Map<Long, PortfolioPdx> region = new ConcurrentHashMap<>();
+
+    prePopulateRegion.run(region, 1, 2, 2);
+
+    // verify that we put the last 50 keys
+    verifyKeys(region, 50, 100);
+  }
+
+  @Test
+  public void putsEntriesForServerWithSmallBatches() throws InterruptedException {
+    PrePopulateRegion prePopulateRegion = new PrePopulateRegion(100);
+    prePopulateRegion.setBatchSize(2);
+
+    Map<Long, PortfolioPdx> region = new ConcurrentHashMap<>();
+
+    prePopulateRegion.run(region, 1, 2, 2);
+
+    // verify that we put the last 50 keys
+    verifyKeys(region, 50, 100);
+  }
+
+  private void verifyKeys(Map<Long, PortfolioPdx> region, int startInclusive, int endExclusive) {
+    List<Long> expectedKeys = LongStream.range(startInclusive, endExclusive)
+        .mapToObj(Long::new)
+        .collect(Collectors.toList());
+
+    assertThat(region.keySet()).containsExactlyInAnyOrderElementsOf(expectedKeys);
+  }
+
+}

--- a/geode-benchmarks/src/test/java/org/apache/geode/benchmark/tasks/PrePopulateRegionTest.java
+++ b/geode-benchmarks/src/test/java/org/apache/geode/benchmark/tasks/PrePopulateRegionTest.java
@@ -22,9 +22,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
+import org.apache.benchmark.geode.data.Portfolio;
 import org.junit.jupiter.api.Test;
-
-import org.apache.geode.benchmark.data.PortfolioPdx;
 
 class PrePopulateRegionTest {
 
@@ -32,7 +31,7 @@ class PrePopulateRegionTest {
   public void putsEntriesForServer() throws InterruptedException {
     PrePopulateRegion prePopulateRegion = new PrePopulateRegion(100);
 
-    Map<Long, PortfolioPdx> region = new ConcurrentHashMap<>();
+    Map<Long, Portfolio> region = new ConcurrentHashMap<>();
 
     prePopulateRegion.run(region, 1, 2, 2);
 
@@ -45,7 +44,7 @@ class PrePopulateRegionTest {
     PrePopulateRegion prePopulateRegion = new PrePopulateRegion(100);
     prePopulateRegion.setBatchSize(2);
 
-    Map<Long, PortfolioPdx> region = new ConcurrentHashMap<>();
+    Map<Long, Portfolio> region = new ConcurrentHashMap<>();
 
     prePopulateRegion.run(region, 1, 2, 2);
 
@@ -53,7 +52,7 @@ class PrePopulateRegionTest {
     verifyKeys(region, 50, 100);
   }
 
-  private void verifyKeys(Map<Long, PortfolioPdx> region, int startInclusive, int endExclusive) {
+  private void verifyKeys(Map<Long, Portfolio> region, int startInclusive, int endExclusive) {
     List<Long> expectedKeys = LongStream.range(startInclusive, endExclusive)
         .mapToObj(Long::new)
         .collect(Collectors.toList());


### PR DESCRIPTION
Prepopulating the region used to occur by means of puts from every
server for every key in the specified range. This resulted in
unnecessarily conflicting puts.

To improve performance of the setup, PrePopulateRegion.run() now divides
the key range as evenly as possible between all servers in the cluster,
prepares the data in a map, then puts the map to the region using
putAll().

The changes result in an observable improvement in performance.