### PR TITLE
Use a dedicated separate profile to work with AWS.

### DIFF
--- a/infrastructure/scripts/aws/README.md
+++ b/infrastructure/scripts/aws/README.md
@@ -4,12 +4,12 @@ These utilities create instances and run tests in your AWS account
 
 # Prerequisites
 * You must have the aws cli installed.
-* You must also set your secret key for the CLI. See the [Amazon's instructions](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
+* You must also set your secret key for the CLI. You must set up a proflie named `geode-benchmarks`, so use the command `aws configure --prefix geode-benchmarks` to configure the CLI. See [Amazon's instructions](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
 * To build the image, you must have packer installed
 
 # Image
 
-Before using the scripts below, build the image in the image directory using packer.
+Before using the scripts below, build the image in the image directory using the `build_image.sh` script.
 
 # launch_cluster.sh
 `launch_cluster.sh` creates an instance group in AWS based on an image created.

--- a/infrastructure/scripts/aws/destroy_cluster.sh
+++ b/infrastructure/scripts/aws/destroy_cluster.sh
@@ -19,6 +19,8 @@
 
 TAG=${1}
 
+export AWS_PROFILE="geode-benchmarks"
+
 pushd ../../../
 ./gradlew destroyCluster --args "${TAG}"
 popd

--- a/infrastructure/scripts/aws/image/build_image.sh
+++ b/infrastructure/scripts/aws/image/build_image.sh
@@ -1,4 +1,21 @@
 #!/usr/bin/env bash
 
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 export AWS_PROFILE="geode-benchmarks"
 packer build packer.json

--- a/infrastructure/scripts/aws/image/build_image.sh
+++ b/infrastructure/scripts/aws/image/build_image.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export AWS_PROFILE="geode-benchmarks"
+packer build packer.json

--- a/infrastructure/scripts/aws/launch_cluster.sh
+++ b/infrastructure/scripts/aws/launch_cluster.sh
@@ -21,6 +21,7 @@ set -e
 
 TAG=${1}
 COUNT=${2}
+export AWS_PROFILE="geode-benchmarks"
 
 pushd ../../../
 ./gradlew launchCluster --args "${TAG} ${COUNT}"

--- a/infrastructure/scripts/aws/run_tests.sh
+++ b/infrastructure/scripts/aws/run_tests.sh
@@ -22,7 +22,8 @@ TAG=${1}
 BRANCH=${2:-develop}
 OUTPUT=${3:-output-${DATE}-${TAG}}
 BENCHMARK_BRANCH=${4:-develop}
-PREFIX="geode-performance-${TAG}"
+PREFIX="geode-benchmarks-${TAG}"
+export AWS_PROFILE="geode-benchmarks"
 
 SSH_OPTIONS="-i ~/.ssh/geode-benchmarks/${TAG}.pem"
 HOSTS=`aws ec2 describe-instances --query 'Reservations[*].Instances[*].PrivateIpAddress' --filter "Name=tag:geode-benchmarks,Values=${TAG}" --output text`


### PR DESCRIPTION
* all scripts now use an AWS profile named `geode-benchmarks`.
* Add script to build AMI.

Authored-by: Sean Goller <sgoller@pivotal.io>