### PR TITLE
GEODE-6233: Use a new hash-map for each PutAll batch in PrePopulateRegion

### DIFF
--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/PrePopulateRegion.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/PrePopulateRegion.java
@@ -131,7 +131,7 @@ public class PrePopulateRegion implements Task {
 
       if (putIndex % getBatchSize() == 0) {
         region.putAll(valueMap);
-        valueMap.clear();
+        valueMap = new HashMap<>();
       }
     }
 

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedGetBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedGetBenchmark.java
@@ -37,7 +37,7 @@ import org.apache.geode.perftest.TestRunners;
  */
 public class PartitionedGetBenchmark implements PerformanceTest {
 
-  private long keyRange = 10000;
+  private long keyRange = 1000000;
 
   @Test
   public void run() throws Exception {

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedPutBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedPutBenchmark.java
@@ -36,7 +36,7 @@ import org.apache.geode.perftest.TestRunners;
  */
 public class PartitionedPutBenchmark implements PerformanceTest {
 
-  private long keyRange = 10000;
+  private long keyRange = 1000000;
 
   public PartitionedPutBenchmark() {}
 

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/ReplicatedGetBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/ReplicatedGetBenchmark.java
@@ -37,7 +37,7 @@ import org.apache.geode.perftest.TestRunners;
  */
 public class ReplicatedGetBenchmark implements PerformanceTest {
 
-  private long keyRange = 10000;
+  private long keyRange = 1000000;
 
   @Test
   public void run() throws Exception {

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/ReplicatedPutBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/ReplicatedPutBenchmark.java
@@ -36,7 +36,7 @@ import org.apache.geode.perftest.TestRunners;
  */
 public class ReplicatedPutBenchmark implements PerformanceTest {
 
-  private long keyRange = 10000;
+  private long keyRange = 1000000;
 
   public ReplicatedPutBenchmark() {}
 


### PR DESCRIPTION
We see an occasional delay/hang when simply clearing and reusing the same
hashmap for multiple putAll requests.  This change creates a new hashmap every
time it starts a new batch.

This also increases the keyRange for the benchmarks from 10k to 1M.

Co-Authored-By: Helena Bales <hbales@pivotal.io>