### PR TITLE
GEODE-6243: New method to get number of members.

### DIFF
--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/PrePopulateRegion.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/PrePopulateRegion.java
@@ -60,8 +60,8 @@ public class PrePopulateRegion implements Task {
   public void run(TestContext context) throws InterruptedException {
     Cache serverCache = (Cache) context.getAttribute("SERVER_CACHE");
     Region<Long, Portfolio> region = serverCache.getRegion("region");
-    int numLocators = context.getHostsForRole(LOCATOR).size();
-    int numServers = context.getHostsForRole(SERVER).size();
+    int numLocators = context.getHostsIDsForRole(LOCATOR).size();
+    int numServers = context.getHostsIDsForRole(SERVER).size();
     int jvmID = context.getJvmID();
 
     run(region, numLocators, numServers, jvmID);

--- a/harness/src/main/java/org/apache/geode/perftest/TestContext.java
+++ b/harness/src/main/java/org/apache/geode/perftest/TestContext.java
@@ -25,6 +25,8 @@ import java.util.Set;
 public interface TestContext extends Serializable {
   Set<InetAddress> getHostsForRole(String role);
 
+  Set<Integer> getHostsIDsForRole(String role);
+
   File getOutputDir();
 
   /**

--- a/harness/src/main/java/org/apache/geode/perftest/runner/DefaultTestContext.java
+++ b/harness/src/main/java/org/apache/geode/perftest/runner/DefaultTestContext.java
@@ -49,6 +49,11 @@ public class DefaultTestContext implements TestContext {
   }
 
   @Override
+  public Set<Integer> getHostsIDsForRole(String role) {
+    return sharedContext.getHostIDsForRole(role);
+  }
+
+  @Override
   public void setAttribute(String attribute, Object value) {
     attributeMap.put(attribute, value);
   }

--- a/harness/src/main/java/org/apache/geode/perftest/runner/SharedContext.java
+++ b/harness/src/main/java/org/apache/geode/perftest/runner/SharedContext.java
@@ -45,4 +45,11 @@ public class SharedContext implements Serializable {
         .map(mapping -> mapping.getNode().getAddress())
         .collect(Collectors.toSet());
   }
+
+  public Set<Integer> getHostIDsForRole(String role) {
+    return jvmMappings.stream()
+        .filter(mapping -> mapping.getRole().equals(role))
+        .map(mapping -> mapping.getId())
+        .collect(Collectors.toSet());
+  }
 }


### PR DESCRIPTION
	* New method added to get the number of members for each role.
	* Calculating unique addresses for number of members caused an issue when all VMs are in the same physical machine.