### PR TITLE
Fix credentials management.

### DIFF
--- a/infrastructure/scripts/aws/destroy_cluster.sh
+++ b/infrastructure/scripts/aws/destroy_cluster.sh
@@ -19,7 +19,9 @@
 
 TAG=${1}
 
-export AWS_PROFILE="geode-benchmarks"
+if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+  export AWS_PROFILE="geode-benchmarks"
+fi
 
 pushd ../../../
 ./gradlew destroyCluster --args "${TAG}"

--- a/infrastructure/scripts/aws/launch_cluster.sh
+++ b/infrastructure/scripts/aws/launch_cluster.sh
@@ -21,7 +21,9 @@ set -e
 
 TAG=${1}
 COUNT=${2}
-export AWS_PROFILE="geode-benchmarks"
+if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+  export AWS_PROFILE="geode-benchmarks"
+fi
 
 pushd ../../../
 ./gradlew launchCluster --args "${TAG} ${COUNT}"

--- a/infrastructure/scripts/aws/run_tests.sh
+++ b/infrastructure/scripts/aws/run_tests.sh
@@ -23,7 +23,10 @@ BRANCH=${2:-develop}
 BENCHMARK_BRANCH=${3:-develop}
 OUTPUT=${4:-output-${DATE}-${TAG}}
 PREFIX="geode-performance-${TAG}"
-export AWS_PROFILE="geode-benchmarks"
+
+if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+  export AWS_PROFILE="geode-benchmarks"
+fi
 
 SSH_OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ~/.ssh/geode-benchmarks/${TAG}.pem"
 HOSTS=`aws ec2 describe-instances --query 'Reservations[*].Instances[*].PrivateIpAddress' --filter "Name=tag:geode-benchmarks,Values=${TAG}" --output text`


### PR DESCRIPTION
* If AWS credentials are provided via environment variables, don't set
  the profile.

Authored-by: Sean Goller <sgoller@pivotal.io>