### PR TITLE
GEODE-6134 - Add analysis after running a benchmark comparison.

### DIFF
--- a/infrastructure/scripts/aws/analyze_tests.sh
+++ b/infrastructure/scripts/aws/analyze_tests.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+OUTPUT_DIR=${1}
+
+TOP_DIR=$(git rev-parse --show-toplevel)
+
+echo ${TOP_DIR}
+
+BASELINE_DIR="${OUTPUT_DIR}/baseline"
+BRANCH_DIR="${OUTPUT_DIR}/branch"
+BASELINE_BENCHMARKS="$(ls -td ${BASELINE_DIR}/benchmarks_* | tail -1)"
+BRANCH_BENCHMARKS="$(ls -td ${BRANCH_DIR}/benchmarks_* | tail -1)"
+pushd ${TOP_DIR}
+./gradlew analyzeRun --args "${BASELINE_BENCHMARKS} ${BRANCH_BENCHMARKS}"
+popd

--- a/infrastructure/scripts/aws/analyze_tests.sh
+++ b/infrastructure/scripts/aws/analyze_tests.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 OUTPUT_DIR=${1}
 
 TOP_DIR=$(git rev-parse --show-toplevel)

--- a/infrastructure/scripts/aws/run_against_baseline.sh
+++ b/infrastructure/scripts/aws/run_against_baseline.sh
@@ -24,5 +24,9 @@ BASELINE=${3:-"rel/v1.8.0"}
 BENCHMARK_BRANCH=${4:-develop}
 DEFAULT_OUTPUT_DIR=output-${DATE}-${TAG}
 OUTPUT=${5:-${DEFAULT_OUTPUT_DIR}}
+if ! [[ "$OUTPUT" = /* ]]; then
+  OUTPUT="$(pwd)/${OUTPUT}"
+fi
 ./run_tests.sh ${TAG} ${BRANCH} ${BENCHMARK_BRANCH} ${OUTPUT}/branch
 ./run_tests.sh ${TAG} ${BASELINE} ${BENCHMARK_BRANCH} ${OUTPUT}/baseline
+./analyze_tests.sh ${OUTPUT}


### PR DESCRIPTION
* Add script to run analysis on an output directory
* Call analyze script from benchmark comparison script.

Authored-by: Sean Goller <sgoller@pivotal.io>