### PR TITLE
GEODE-6275: Fail Benchmark job when build fails

### DIFF
--- a/infrastructure/scripts/aws/run_against_baseline.sh
+++ b/infrastructure/scripts/aws/run_against_baseline.sh
@@ -17,6 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e -o pipefail
+
 DATE=$(date '+%m-%d-%Y-%H-%M-%S')
 TAG=${1}
 BRANCH=${2:-develop}
@@ -27,6 +29,7 @@ OUTPUT=${5:-${DEFAULT_OUTPUT_DIR}}
 if ! [[ "$OUTPUT" = /* ]]; then
   OUTPUT="$(pwd)/${OUTPUT}"
 fi
+
 ./run_tests.sh ${TAG} ${BRANCH} ${BENCHMARK_BRANCH} ${OUTPUT}/branch
 ./run_tests.sh ${TAG} ${BASELINE} ${BENCHMARK_BRANCH} ${OUTPUT}/baseline
 ./analyze_tests.sh ${OUTPUT}

--- a/infrastructure/scripts/aws/run_tests.sh
+++ b/infrastructure/scripts/aws/run_tests.sh
@@ -16,6 +16,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+set -e -o pipefail
+
 DATE=$(date '+%m-%d-%Y-%H-%M-%S')
 
 TAG=${1}


### PR DESCRIPTION
Fail the benchmark job when it fails to build or get resources from
Maven.

Co-authored-by: Jacob Barrett <jbarrett@pivotal.io>