### PR TITLE
set -e so errors aren't masked.

### DIFF
--- a/infrastructure/scripts/aws/analyze_tests.sh
+++ b/infrastructure/scripts/aws/analyze_tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+set -e
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
This would cause the benchmark job in the geode pipeline to stay green even though the benchmark failed.