### PR TITLE
Exclude PartitionedIndexedQueryBenchmark.

### DIFF
--- a/geode-benchmarks/build.gradle
+++ b/geode-benchmarks/build.gradle
@@ -62,6 +62,7 @@ task benchmark(type: Test) {
     }
 
     exclude "**/*Function*Benchmark.class"
+    exclude "**/PartitionedIndexQueryBenchmark.class"
     forkEvery 1
 
     systemProperty 'TEST_HOSTS', project.findProperty('hosts')


### PR DESCRIPTION
The variance is too large on this.

Authored-by: Sean Goller <sgoller@pivotal.io>