### PR TITLE
GEODE-6394: set pool idle-timeout to be infinite

### DIFF
--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartClient.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartClient.java
@@ -48,6 +48,7 @@ public class StartClient implements Task {
     ClientCache clientCache = new ClientCacheFactory(GeodeProperties.clientProperties())
         .setPdxSerializer(new ReflectionBasedAutoSerializer("benchmark.geode.data.*"))
         .addPoolLocator(locator.getHostAddress(), locatorPort)
+        .setPoolIdleTimeout(-1)
         .set(ConfigurationProperties.STATISTIC_ARCHIVE_FILE, statsFile)
         .create();
 


### PR DESCRIPTION
The client was dropping connections to the server when it shouldn't
have. Setting the pool's idle-timeout from the default of 5 seconds to
have no limit resolved this issue.