### PR TITLE
GEODE-6444: Store GC logs in files

### DIFF
--- a/geode-benchmarks/build.gradle
+++ b/geode-benchmarks/build.gradle
@@ -61,8 +61,6 @@ task benchmark(type: Test) {
         exceptionFormat = 'full'
     }
 
-    exclude "**/*Function*Benchmark.class"
-    exclude "**/PartitionedIndexQueryBenchmark.class"
     forkEvery 1
 
     systemProperty 'TEST_HOSTS', project.findProperty('hosts')

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/JVMLauncher.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/JVMLauncher.java
@@ -56,6 +56,8 @@ class JVMLauncher {
       public void run() {
 
         try {
+          infra.onNode(jvmConfig.getNode(), new String[] {"rm", "-rf", jvmConfig.getOutputDir()});
+          infra.onNode(jvmConfig.getNode(), new String[] {"mkdir", "-p", jvmConfig.getOutputDir()});
           int result = infra.onNode(jvmConfig.getNode(), shellCommand);
           if (result != 0) {
             logger.error("ChildJVM exited with error code " + result);
@@ -83,6 +85,7 @@ class JVMLauncher {
     command.add("-D" + RemoteJVMFactory.RMI_PORT_PROPERTY + "=" + rmiPort);
     command.add("-D" + RemoteJVMFactory.JVM_ID + "=" + jvmConfig.getId());
     command.add("-D" + RemoteJVMFactory.OUTPUT_DIR + "=" + jvmConfig.getOutputDir());
+    command.add("-Xloggc:" + jvmConfig.getOutputDir() + "/gc.log");
     command.addAll(jvmConfig.getJvmArgs());
     command.add(ChildJVM.class.getName());
 

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/ChildJVM.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/ChildJVM.java
@@ -21,8 +21,6 @@ import java.io.File;
 import java.io.PrintStream;
 import java.rmi.RemoteException;
 
-import org.apache.commons.io.FileUtils;
-
 import org.apache.geode.perftest.jdk.RMI;
 import org.apache.geode.perftest.jdk.SystemInterface;
 import org.apache.geode.perftest.jvms.RemoteJVMFactory;
@@ -62,9 +60,6 @@ public class ChildJVM {
       }
 
       File outputDir = new File(OUTPUT_DIR);
-      // Clean up the output directory before the test runs
-      FileUtils.deleteQuietly(outputDir);
-      outputDir.mkdirs();
       try (PrintStream out = new PrintStream(new File(outputDir, "system.log"))) {
         system.setOut(out);
         system.setErr(out);

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/Controller.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/Controller.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.geode.perftest.Task;
@@ -39,6 +41,7 @@ public class Controller extends UnicastRemoteObject implements ControllerRemote 
   private final Map<Integer, WorkerRemote> workers = new ConcurrentHashMap<>();
   private final CountDownLatch workersStarted;
   private volatile boolean isClosed;
+  private ExecutorService workerExecutionPool = Executors.newCachedThreadPool();
 
 
   Controller(int numWorkers, Registry registry, SharedContext context) throws RemoteException {
@@ -85,6 +88,6 @@ public class Controller extends UnicastRemoteObject implements ControllerRemote 
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
-    });
+    }, workerExecutionPool);
   }
 }

--- a/harness/src/main/java/org/apache/geode/perftest/yardstick/YardstickTask.java
+++ b/harness/src/main/java/org/apache/geode/perftest/yardstick/YardstickTask.java
@@ -27,7 +27,6 @@ import org.yardstickframework.BenchmarkProbe;
 import org.yardstickframework.impl.BenchmarkLoader;
 import org.yardstickframework.impl.BenchmarkProbeSet;
 import org.yardstickframework.impl.BenchmarkRunner;
-import org.yardstickframework.probes.DStatProbe;
 import org.yardstickframework.probes.PercentileProbe;
 import org.yardstickframework.probes.ThroughputLatencyProbe;
 import org.yardstickframework.probes.VmStatProbe;
@@ -95,7 +94,7 @@ public class YardstickTask implements Task {
     Collection<BenchmarkProbe> probes =
         Arrays.asList(new HdrHistogramProbe(new HdrHistogramWriter(context.getOutputDir())),
             new ThroughputLatencyProbe(),
-            new PercentileProbe(), new DStatProbe(), new VmStatProbe(),
+            new PercentileProbe(), new VmStatProbe(),
             testDoneProbe);
     BenchmarkLoader loader = new BenchmarkLoader();
     loader.initialize(cfg);

--- a/harness/src/test/java/org/apache/geode/perftest/jvms/rmi/ChildJVMTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/jvms/rmi/ChildJVMTest.java
@@ -20,7 +20,6 @@ package org.apache.geode.perftest.jvms.rmi;
 import static org.apache.geode.perftest.jvms.RemoteJVMFactory.OUTPUT_DIR;
 import static org.apache.geode.perftest.jvms.RemoteJVMFactory.RMI_HOST;
 import static org.apache.geode.perftest.jvms.RemoteJVMFactory.RMI_PORT_PROPERTY;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -83,15 +82,4 @@ public class ChildJVMTest {
 
     verify(controller, times(3)).ping();
   }
-
-  @Test
-  public void childCleansOutputDir() throws IOException {
-    File expectedFile = new File(folder, "somefile.txt");
-    expectedFile.createNewFile();
-
-    jvm.run();
-
-    assertFalse(expectedFile.exists());
-  }
-
 }


### PR DESCRIPTION
	* Store the GC logs in a file.
	* Print the GC logs in the System.out / System.err in parallel while the benchmark is being executed in parallel.
	* Using a thread pool for execution of runAsync and not depend on fork join pools