### PR TITLE
Refactor metadata production and management.

### DIFF
--- a/gradle/dependency-versions.properties
+++ b/gradle/dependency-versions.properties
@@ -28,3 +28,4 @@ awaitility.version = 3.0.0
 sshd-core.version = 2.1.0
 assertj-core.version = 3.11.1
 software-amazon-awssdk.version = 2.1.4
+JSON.version = 20180813

--- a/harness/build.gradle
+++ b/harness/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     compile(group: 'commons-io', name: 'commons-io', version: project.'commons-io.version')
     compile(group: 'org.yardstickframework', name: 'yardstick', version: project.'yardstick.version')
     compile(group: 'org.hdrhistogram', name: 'HdrHistogram', version: project.'HdrHistogram.version')
+    compile(group: 'org.json', name: 'json', version: project.'JSON.version')
     testCompile(group: 'org.mockito', name: 'mockito-all', version: project.'mockito-all.version')
     testCompile(group: 'org.awaitility', name: 'awaitility', version: project.'awaitility.version')
     testCompile(group: 'org.slf4j', name: 'slf4j-simple', version: project.'slf4j-simple.version')

--- a/harness/src/main/java/org/apache/geode/perftest/runner/DefaultTestRunner.java
+++ b/harness/src/main/java/org/apache/geode/perftest/runner/DefaultTestRunner.java
@@ -22,6 +22,7 @@ import java.io.FileWriter;
 import java.util.List;
 import java.util.Map;
 
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,9 +77,15 @@ public class DefaultTestRunner implements TestRunner {
       FileWriter metadataWriter = new FileWriter(metadataOutput.getAbsoluteFile(), true);
 
       String[] metadataEntries = metadata.split(",");
+      JSONObject JSONmetadata = new JSONObject();
+
       for (String data : metadataEntries) {
-        metadataWriter.write(data + "\n");
+        String[] kv = data.split(":");
+        if (kv.length == 2) {
+          JSONmetadata.put(kv[0], kv[1]);
+        }
       }
+      metadataWriter.write(JSONmetadata.toString());
       metadataWriter.flush();
     }
 

--- a/harness/src/main/java/org/apache/geode/perftest/yardstick/hdrhistogram/HdrHistogramWriter.java
+++ b/harness/src/main/java/org/apache/geode/perftest/yardstick/hdrhistogram/HdrHistogramWriter.java
@@ -26,14 +26,17 @@ import org.HdrHistogram.HistogramLogWriter;
 public class HdrHistogramWriter implements Consumer<Histogram> {
 
   public static final String FILE_NAME = "latency.hlog";
+  public static final String FILE_NAME_CSV = "latency_csv";
   public static final String FILE_NAME_HDR = "latency_hdr";
 
   private final File outputFile;
   private final File outputHDRFile;
+  private final File outputCSVFile;
 
   public HdrHistogramWriter(File outputDir) {
     this.outputFile = new File(outputDir, FILE_NAME);
     this.outputHDRFile = new File(outputDir, FILE_NAME_HDR);
+    this.outputCSVFile = new File(outputDir, FILE_NAME_CSV);
   }
 
   @Override
@@ -51,6 +54,10 @@ public class HdrHistogramWriter implements Consumer<Histogram> {
           new HistogramLogProcessor(new String[] {"-i", outputFile.getAbsolutePath(), "-o",
               outputHDRFile.getAbsolutePath()});
       histogramLogProcessor.run();
+      HistogramLogProcessor histogramLogProcessorCSV =
+          new HistogramLogProcessor(new String[] {"-csv", "-i", outputFile.getAbsolutePath(), "-o",
+              outputCSVFile.getAbsolutePath()});
+      histogramLogProcessorCSV.run();
     } catch (FileNotFoundException e) {
       throw new UncheckedIOException(e);
     }

--- a/infrastructure/build.gradle
+++ b/infrastructure/build.gradle
@@ -28,6 +28,7 @@ repositories {
 }
 
 dependencies {
+    implementation(group: 'org.json', name: 'json', version: project.'JSON.version')
     implementation 'software.amazon.awssdk:ec2'
     implementation(group: 'com.hierynomus', name: 'sshj', version: project.'sshj.version')
     runtime(group: 'org.slf4j', name: 'slf4j-simple', version: project.'slf4j-simple.version')

--- a/infrastructure/src/main/java/org/apache/geode/infrastructure/BenchmarkMetadata.java
+++ b/infrastructure/src/main/java/org/apache/geode/infrastructure/BenchmarkMetadata.java
@@ -21,7 +21,6 @@ package org.apache.geode.infrastructure;
  */
 public class BenchmarkMetadata {
   public static String PREFIX = "geode-benchmarks";
-  public static String SSH_DIRECTORY = ".ssh/geode-benchmarks";
 
   public static String benchmarkPrefix(String tag) {
     return PREFIX + "-" + tag;
@@ -31,11 +30,16 @@ public class BenchmarkMetadata {
     return benchmarkPrefix(tag) + "-" + suffix;
   }
 
-  public static String benchmarkKeyFileDirectory() {
-    return System.getProperty("user.home") + "/" + SSH_DIRECTORY;
+  public static String benchmarkConfigDirectory() {
+    return System.getProperty("user.home") + "/." + PREFIX;
   }
 
-  public static String benchmarkKeyFileName(String tag) {
-    return benchmarkKeyFileDirectory() + "/" + tag + ".pem";
+
+  public static String benchmarkPrivateKeyFileName(String tag) {
+    return benchmarkConfigDirectory() + "/" + tag + "-privkey.pem";
+  }
+
+  public static String benchmarkMetadataFileName(String tag) {
+    return benchmarkConfigDirectory() + "/" + tag + "-metadata.json";
   }
 }

--- a/infrastructure/src/main/java/org/apache/geode/infrastructure/aws/AwsBenchmarkMetadata.java
+++ b/infrastructure/src/main/java/org/apache/geode/infrastructure/aws/AwsBenchmarkMetadata.java
@@ -48,7 +48,11 @@ class AwsBenchmarkMetadata extends BenchmarkMetadata {
   }
 
   public static String keyPairFileName(String tag) {
-    return BenchmarkMetadata.benchmarkKeyFileName(tag);
+    return BenchmarkMetadata.benchmarkPrivateKeyFileName(tag);
+  }
+
+  public static String metadataFileName(String tag) {
+    return BenchmarkMetadata.benchmarkMetadataFileName(tag);
   }
 
   public static InstanceType instanceType() {

--- a/infrastructure/src/main/java/org/apache/geode/infrastructure/aws/DestroyCluster.java
+++ b/infrastructure/src/main/java/org/apache/geode/infrastructure/aws/DestroyCluster.java
@@ -55,6 +55,7 @@ public class DestroyCluster {
     deleteSecurityGroup(benchmarkTag);
     deletePlacementGroup(benchmarkTag);
     deleteKeyPair(benchmarkTag);
+    deleteMetadata(benchmarkTag);
   }
 
   private static void deleteKeyPair(String benchmarkTag) {
@@ -65,6 +66,16 @@ public class DestroyCluster {
           .build());
       Files.deleteIfExists(Paths.get(AwsBenchmarkMetadata.keyPairFileName(benchmarkTag)));
       System.out.println("Key Pair for cluster '" + benchmarkTag + "' deleted.");
+    } catch (Exception e) {
+      System.out.println("We got an exception while deleting the Key pair");
+      System.out.println("Exception message: " + e);
+    }
+  }
+
+  private static void deleteMetadata(String benchmarkTag) {
+    try {
+      Files.deleteIfExists(Paths.get(AwsBenchmarkMetadata.metadataFileName(benchmarkTag)));
+      System.out.println("Metadata for cluster '" + benchmarkTag + "' deleted.");
     } catch (Exception e) {
       System.out.println("We got an exception while deleting the Key pair");
       System.out.println("Exception message: " + e);


### PR DESCRIPTION
* Tests now output metadata if the metadata file doesn't exist.
* benchmark run metadata.json is actually json.
* Create configuration directory to store cluster information.
* Move SSH private key for cluster to configuration directory.
* Create metadata for cluster, currently including an instance ID and
  the list of IPs in the cluster.
* Delete metadata when the cluster is destroyed.