### PR TITLE
GEODE-6479: add username to aws keypair prefix

### DIFF
--- a/infrastructure/build.gradle
+++ b/infrastructure/build.gradle
@@ -46,10 +46,14 @@ task(launchCluster, dependsOn: 'classes', type: JavaExec) {
     main = 'org.apache.geode.infrastructure.aws.LaunchCluster'
     workingDir = rootDir
     classpath = sourceSets.main.runtimeClasspath
+
+    systemProperty 'TEST_CI', project.findProperty('ci')
 }
 
 task(destroyCluster, dependsOn: 'classes', type: JavaExec) {
     main = 'org.apache.geode.infrastructure.aws.DestroyCluster'
     workingDir = rootDir
     classpath = sourceSets.main.runtimeClasspath
+
+    systemProperty 'TEST_CI', project.findProperty('ci')
 }

--- a/infrastructure/scripts/aws/destroy_cluster.sh
+++ b/infrastructure/scripts/aws/destroy_cluster.sh
@@ -17,12 +17,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG=${1}
+TAG=
+CI=
+
+while :; do
+  case $1 in
+    -t|--tag )
+      if [ "$2" ]; then
+        TAG=$2
+        shift
+      else
+        echo 'ERROR: "--tag" requires a non-empty argument.'
+        exit 1
+      fi
+      ;;
+    --ci )
+      CI=1
+      ;;
+    -h|--help|-\? )
+      echo "Usage: $(basename "$0") -t tag -c 4 [options ...] [-- arguments ...]"
+      echo "Options:"
+      echo "-t|--tag : Cluster tag"
+      echo "--ci : Set if starting instances for Continuous Integration"
+      echo "-- : All subsequent arguments are passed to the benchmark task as arguments."
+      echo "-h|--help : This help message"
+      exit 1
+      ;;
+    -- )
+      shift
+      break
+      ;;
+    -?* )
+      printf 'Invalid option: %s\n' "$1" >&2
+      break
+      ;;
+    * )
+      break
+  esac
+  shift
+done
 
 if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
   export AWS_PROFILE="geode-benchmarks"
 fi
 
+if [ -z "${CI}" ]; then
+  CI=0
+fi
+
 pushd ../../../
-./gradlew destroyCluster --args "${TAG}"
+./gradlew destroyCluster -Pci=${CI} --args "${TAG}"
 popd

--- a/infrastructure/scripts/aws/launch_cluster.sh
+++ b/infrastructure/scripts/aws/launch_cluster.sh
@@ -19,12 +19,65 @@
 
 set -e
 
-TAG=${1}
-COUNT=${2}
+TAG=
+COUNT=
+CI=
+
+while :; do
+  case $1 in
+    -t|--tag )
+      if [ "$2" ]; then
+        TAG=$2
+        shift
+      else
+        echo 'ERROR: "--tag" requires a non-empty argument.'
+        exit 1
+      fi
+      ;;
+    -c|--count )
+      if [ "$2" ]; then
+        COUNT=$2
+        shift
+      else
+        echo 'ERROR: "--count" requires a non-empty argument.'
+        exit 1
+      fi
+      ;;
+    --ci )
+      CI=1
+      ;;
+    -h|--help|-\? )
+      echo "Usage: $(basename "$0") -t tag -c 4 [options ...] [-- arguments ...]"
+      echo "Options:"
+      echo "-t|--tag : Cluster tag"
+      echo "-c|--count : The number of instances to start"
+      echo "--ci : Set if starting instances for Continuous Integration"
+      echo "-- : All subsequent arguments are passed to the benchmark task as arguments."
+      echo "-h|--help : This help message"
+      exit 1
+      ;;
+    -- )
+      shift
+      break
+      ;;
+    -?* )
+      printf 'Invalid option: %s\n' "$1" >&2
+      break
+      ;;
+    * )
+      break
+  esac
+  shift
+done
+
 if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
   export AWS_PROFILE="geode-benchmarks"
 fi
 
+if [ -z "${CI}" ]; then
+  CI=0
+fi
+
 pushd ../../../
-./gradlew launchCluster --args "${TAG} ${COUNT}"
+./gradlew launchCluster -Pci=${CI} --args "${TAG} ${COUNT}"
 popd

--- a/infrastructure/src/main/java/org/apache/geode/infrastructure/BenchmarkMetadata.java
+++ b/infrastructure/src/main/java/org/apache/geode/infrastructure/BenchmarkMetadata.java
@@ -23,7 +23,11 @@ public class BenchmarkMetadata {
   public static String PREFIX = "geode-benchmarks";
 
   public static String benchmarkPrefix(String tag) {
-    return PREFIX + "-" + System.getProperty("user.name") + "-" + tag;
+    if(System.getProperty("TEST_CI").equals("1")) {
+      return PREFIX + "-" + tag;
+    } else {
+      return PREFIX + "-" + System.getProperty("user.name") + "-" + tag;
+    }
   }
 
   public static String benchmarkString(String tag, String suffix) {

--- a/infrastructure/src/main/java/org/apache/geode/infrastructure/BenchmarkMetadata.java
+++ b/infrastructure/src/main/java/org/apache/geode/infrastructure/BenchmarkMetadata.java
@@ -23,7 +23,7 @@ public class BenchmarkMetadata {
   public static String PREFIX = "geode-benchmarks";
 
   public static String benchmarkPrefix(String tag) {
-    return PREFIX + "-" + tag;
+    return PREFIX + "-" + System.getProperty("user.name") + "-" + tag;
   }
 
   public static String benchmarkString(String tag, String suffix) {

--- a/infrastructure/src/main/java/org/apache/geode/infrastructure/BenchmarkMetadata.java
+++ b/infrastructure/src/main/java/org/apache/geode/infrastructure/BenchmarkMetadata.java
@@ -23,7 +23,7 @@ public class BenchmarkMetadata {
   public static String PREFIX = "geode-benchmarks";
 
   public static String benchmarkPrefix(String tag) {
-    if(System.getProperty("TEST_CI").equals("1")) {
+    if (System.getProperty("TEST_CI").equals("1")) {
       return PREFIX + "-" + tag;
     } else {
       return PREFIX + "-" + System.getProperty("user.name") + "-" + tag;


### PR DESCRIPTION
Get the current username from system properties and add it to the aws
prefix to make the instance owners more immediately identifiable. This
should help reduce the number of instances that are left running with no
clear owner.