### PR TITLE
GEODE-6480: pass on CLI options after '--' for AWS scripts

### DIFF
--- a/infrastructure/scripts/aws/destroy_cluster.sh
+++ b/infrastructure/scripts/aws/destroy_cluster.sh
@@ -35,7 +35,7 @@ while :; do
       CI=1
       ;;
     -h|--help|-\? )
-      echo "Usage: $(basename "$0") -t tag -c 4 [options ...] [-- arguments ...]"
+      echo "Usage: $(basename "$0") -t tag [options ...] [-- arguments ...]"
       echo "Options:"
       echo "-t|--tag : Cluster tag"
       echo "--ci : Set if starting instances for Continuous Integration"
@@ -45,7 +45,7 @@ while :; do
       ;;
     -- )
       shift
-      break
+      break 2
       ;;
     -?* )
       printf 'Invalid option: %s\n' "$1" >&2

--- a/infrastructure/scripts/aws/launch_cluster.sh
+++ b/infrastructure/scripts/aws/launch_cluster.sh
@@ -58,7 +58,7 @@ while :; do
       ;;
     -- )
       shift
-      break
+      break 2
       ;;
     -?* )
       printf 'Invalid option: %s\n' "$1" >&2

--- a/infrastructure/scripts/aws/run_against_baseline.sh
+++ b/infrastructure/scripts/aws/run_against_baseline.sh
@@ -129,7 +129,7 @@ while :; do
       ;;
     -- )
       shift
-      break
+      break 2
       ;;
     -?* )
       printf 'Invalid option: %s\n' "$1" >&2

--- a/infrastructure/scripts/aws/run_tests.sh
+++ b/infrastructure/scripts/aws/run_tests.sh
@@ -104,7 +104,7 @@ while :; do
       ;;
     -- )
       shift
-      break
+      break 2
       ;;
     -?* )
       printf 'Invalid option: %s\n' "$1" >&2


### PR DESCRIPTION
break out of the case statement so that options after '--' when running
tests and running against the baseline are passed on to gradle.