### PR TITLE
GEODE-6502: update README

### DIFF
--- a/infrastructure/scripts/aws/README.md
+++ b/infrastructure/scripts/aws/README.md
@@ -4,7 +4,7 @@ These utilities create instances and run tests in your AWS account
 
 # Prerequisites
 * You must have the aws cli installed.
-* You must also set your secret key for the CLI. You must set up a proflie named `geode-benchmarks`, so use the command `aws configure --profile geode-benchmarks` to configure the CLI. See [Amazon's instructions](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
+* You must also set your secret key for the CLI. You must set up a profile named `geode-benchmarks`, so use the command `aws configure --profile geode-benchmarks` to configure the CLI. See [Amazon's instructions](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
 * To build the image, you must have packer installed
 
 # Image
@@ -12,10 +12,18 @@ These utilities create instances and run tests in your AWS account
 Before using the scripts below, build the image in the image directory using the `build_image.sh` script.
 
 # launch_cluster.sh
-`launch_cluster.sh` creates an instance group in AWS based on an image created.
+Creates an instance group in AWS based on an image created.
 
-It takes two arguments. First, a tag to identify the cluster for use with other utilities. The
-second argument is the number of instances to create. 
+Usage:
+
+    ./launch_cluster.sh -t [tag] -c [count] [--ci]
+
+Options:
+    
+    -t|--tag     : Cluster tag to identify the cluster for use with other utilities
+    -c|--count   : Number of AWS instances to start (recommended: 4)
+    --ci         : (Optional) Set when the instances are being started for use in Continuous Integration
+    -h|-?|--help : Help message
 
 # run_tests.sh
 Runs benchmark tests against a single branch of `geode` on the AWS instances with the specified tag.
@@ -26,13 +34,16 @@ Usage:
 
 Options:
     
-    -e : Benchmark branch (optional - defaults to develop)
-    -o : Output directory (optional - defaults to ./output-<date>-<tag>)
-    -v : Geode Version
-    -b : Geode Branch
-    -t : Cluster tag
-    -m : Test metadata to output to file, comma-delimited (optional)
-    -h : Help message
+    -t|--tag                        : Cluster tag
+    -p|--br|--benchmark-repo        : Benchmark repo (default: apache/geode-benchmarks)
+    -e|--bb|--benchmark-branch      : Benchmark branch (optional - defaults to develop)
+    -o|--output                     : Output directory (optional - defaults to ./output-<date>-<tag>)
+    -v|--version|--geode-version    : Geode Version
+    -r|--gr|--geode-repo            : Geode repo (default: apache/geode)
+    -b|--gb|--branch|--geode-branch : Geode Branch (default: develop)
+    -m|--metadata                   : Test metadata to output to file, comma-delimited (optional)
+    --                              : All subsequent arguments are passed to the benchmark tast as arguments
+    -h|-?|--help                    : Help message
 
 # run_against_baseline.sh
 Runs benchmark tests against two branches of geode for comparison purposes on the AWS instances with
@@ -43,33 +54,47 @@ Usage:
     run_test.sh -t [tag] [-v [version] | -b [branch]] [-V [baseline version] | -B [baseline branch]] <options...>"
 
 Options:
-            
-    -e : Benchmark branch (optional - defaults to develop)
-    -o : Output directory (optional - defaults to ./output-<date>-<tag>)
-    -v : Geode Version
-    -b : Geode Branch
-    -V : Geode Baseline Version
-    -B : Geode Baseline Branch
-    -t : Cluster tag
-    -m : Test metadata to output to file, comma-delimited (optional)
-    -h : Help message
+           
+    -t|--tag                                             : Cluster tag
+    -p|--br|--benchmark-repo                             : Benchmark repo (default: apache/geode-benchmarks) 
+    -e|--bb|--benchmark-branch                           : Benchmark branch (optional - defaults to develop)
+    -o|--output                                          : Output directory (optional - defaults to ./output-<date>-<tag>)
+    -v|--version|--geode-version                         : Geode Version
+    -r|--gr|--repo|--geode-repo                          : Geode repo (default: apache/geode)
+    -b|--gb|--branch|--geode-branch                      : Geode Branch (default: develop)
+    -R|--bgr|--baseline-repo|--baseline-geode-repo       : Geode Baseline Repo (default: apache/geode)
+    -V|--bgv|--baseline-version|--baseline-geode-version : Geode Baseline Version
+    -B|--gbb|--baseline-branch|--baseline-geode-branch   : Geode Baseline Branch (default: develop)
+    -m|--metadata                                        : Test metadata to output to file, comma-delimited (optional)
+    -h|-?|--help                                         : Help message
 
 
 # destroy_cluster.sh
-Destroys a cluster that you created. Arguments are the tag that you passed to launch_cluster.sh
+Destroys a cluster that you created.
+
+Usage:
+
+    ./destroy_cluster.sh -t [tag] [--ci]
+    
+Options:
+    
+    -t|--tag     : Cluster tag to identify the cluster for use with other utilities
+    --ci         : (Optional) Set when the instances are being started for use in Continuous Integration
+    -h|-?|--help : Help message
+
 
 #Example
 
 Example 1 - run_test.sh:
 ```bash
-./launch_cluster.sh mycluster 4
-./run_tests.sh -t mycluster -b develop -e benchmarkBranch -m "'name':'HelenaTestingCPUs','CPU':'256','geodeBranch':'CPUTest'"
-./destroy_cluster.sh mycluster
+./launch_cluster.sh --tag mycluster --count 4
+./run_tests.sh --tag mycluster --geode-branch develop --benchmark-branch benchmarkBranch --metadata "'name':'HelenaTestingCPUs','CPU':'256','geodeBranch':'CPUTest'"
+./destroy_cluster.sh --tag mycluster
 ```
 
 Example 2 - run_against_baseline.sh:
 ```bash
-./launch_cluster.sh mycluster 4
-./run-tests -t mycluster -b develop -e benchmarkBranch -m "'name':'HelenaTestingCPUs','CPU':'256','geodeBranch':'CPUTest'"
-./destroy_cluster.sh mycluster
+./launch_cluster.sh --tag mycluster --count 4
+./run-tests --tag mycluster --geode-branch develop --benchmark-branch benchmarkBranch --metadata "'name':'HelenaTestingCPUs','CPU':'256','geodeBranch':'CPUTest'"
+./destroy_cluster.sh --tag mycluster
 ```


### PR DESCRIPTION
Update the readme to reflect all recent script changes, including
changing from positional to named arguments for launching and destroying
clusters, the addition of a --ci option for launching and destroying
clusters for use in continuous integration, and the addition of long
command line options for all scripts.