### PR TITLE
Set membership timeout to be more resilient to benchmark load

### DIFF
--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/GeodeProperties.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/GeodeProperties.java
@@ -51,6 +51,7 @@ public class GeodeProperties {
     properties.setProperty(ConfigurationProperties.ENABLE_TIME_STATISTICS, "true");
     properties.setProperty(ConfigurationProperties.LOG_LEVEL, "config");
     properties.setProperty(ConfigurationProperties.STATISTIC_SAMPLING_ENABLED, "true");
+    properties.setProperty(ConfigurationProperties.MEMBER_TIMEOUT, "8000");
     return properties;
 
   }


### PR DESCRIPTION
Set membership timeout to be more resilient to benchmark load.
Setting membership timeout to 8s.