### PR TITLE
GEODE-7154: Scripts fail with "Too many authentication failures"

### DIFF
--- a/infrastructure/scripts/aws/copy_to_cluster.sh
+++ b/infrastructure/scripts/aws/copy_to_cluster.sh
@@ -60,7 +60,7 @@ if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
   export AWS_PROFILE="geode-benchmarks"
 fi
 
-SSH_OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ~/.geode-benchmarks/${TAG}-privkey.pem"
+SSH_OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ~/.geode-benchmarks/${TAG}-privkey.pem"
 HOSTS=`aws ec2 describe-instances --query 'Reservations[*].Instances[*].PublicIpAddress' --filter "Name=tag:geode-benchmarks,Values=${TAG}" --output text`
 
 for host in ${HOSTS}; do

--- a/infrastructure/scripts/aws/run_on_cluster.sh
+++ b/infrastructure/scripts/aws/run_on_cluster.sh
@@ -60,7 +60,7 @@ if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
   export AWS_PROFILE="geode-benchmarks"
 fi
 
-SSH_OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ~/.geode-benchmarks/${TAG}-privkey.pem"
+SSH_OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ~/.geode-benchmarks/${TAG}-privkey.pem"
 HOSTS=`aws ec2 describe-instances --query 'Reservations[*].Instances[*].PublicIpAddress' --filter "Name=tag:geode-benchmarks,Values=${TAG}" --output text`
 
 for host in ${HOSTS}; do

--- a/infrastructure/scripts/aws/run_tests.sh
+++ b/infrastructure/scripts/aws/run_tests.sh
@@ -141,7 +141,7 @@ fixRepoName() {
 BENCHMARK_REPO=$(fixRepoName ${BENCHMARK_REPO})
 REPO=$(fixRepoName ${REPO})
 
-SSH_OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ~/.geode-benchmarks/${TAG}-privkey.pem"
+SSH_OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ~/.geode-benchmarks/${TAG}-privkey.pem"
 HOSTS=`aws ec2 describe-instances --query 'Reservations[*].Instances[*].PrivateIpAddress' --filter "Name=tag:geode-benchmarks,Values=${TAG}" --output text`
 HOSTS=$(echo ${HOSTS} | tr ' ' ',')
 FIRST_INSTANCE=`aws ec2 describe-instances --query 'Reservations[*].Instances[*].PublicIpAddress' --filter "Name=tag:geode-benchmarks,Values=${TAG}" --output text | cut -f 1`


### PR DESCRIPTION
By adding the IdentitiesOnly=yes option to the SSH options, only the relevant keys will be offered to the SSH server, preventing "too many authentication failures."