### PR TITLE
Fix hash map keys in PutAllTask

### DIFF
--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/PutAllTask.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/PutAllTask.java
@@ -51,9 +51,10 @@ public class PutAllTask extends BenchmarkDriverAdapter implements Serializable {
 
   @Override
   public boolean test(Map<Object, Object> ctx) {
-    final long key = keyRange.random();
+    long key;
     final HashMap<Object, Object> batch = new HashMap<>(batchSize);
     for (int i = 0; i < batchSize; i++) {
+      key = keyRange.random();
       batch.put(key, new Portfolio(key));
     }
     region.putAll(batch);


### PR DESCRIPTION
PutAllTask creates a hash map and fills it with the same key value. This produces a lot of garbage and results in high cpu load on client.