### PR TITLE
Enabled PutAll benchmarks

### DIFF
--- a/geode-benchmarks/build.gradle
+++ b/geode-benchmarks/build.gradle
@@ -62,7 +62,6 @@ task benchmark(type: Test) {
   testLogging { exceptionFormat = 'full' }
 
   exclude "**/*NonIndexedQueryBenchmark.class"
-  exclude "**/*PutAllBenchmark.class"
 
   forkEvery 1
 


### PR DESCRIPTION
The fix in PR #105 stabilized PartitionedPutAllBenchmark and ReplicatedPutAllBenchmark, so there is no need to exclude them anymore.