### PR TITLE
stabilize putall tests

### DIFF
--- a/geode-benchmarks/build.gradle
+++ b/geode-benchmarks/build.gradle
@@ -66,7 +66,6 @@ task benchmark(type: Test) {
   exclude "**/*NonIndexedQueryBenchmark.class"
   exclude "**/PartitionedFunctionExecutionBenchmark.class"
   exclude "**/NoopBenchmark.class"
-  exclude "**/*AllBenchmark.class"
   exclude "**/*LongBenchmark.class"
 
   forkEvery 1

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedPutAllBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedPutAllBenchmark.java
@@ -39,7 +39,7 @@ public class PartitionedPutAllBenchmark implements PerformanceTest {
 
   private LongRange keyRange = new LongRange(0, 1000000);
 
-  private int batchSize = 1000;
+  private int batchSize = 100;
 
   public PartitionedPutAllBenchmark() {}
 


### PR DESCRIPTION
Stabilize the putall tests by reducing the payload size to 100 entries, and decreasing the amount of garbage produced during the test on the client side.
This commit also re-enables the PutAll tests so they will run in CI and whenever all benchmarks are run.