### PR TITLE
Exclude failing NoopBenchmark

### DIFF
--- a/geode-benchmarks/build.gradle
+++ b/geode-benchmarks/build.gradle
@@ -63,6 +63,8 @@ task benchmark(type: Test) {
   useJUnitPlatform()
   testLogging { exceptionFormat = 'full' }
 
+  exclude "**/NoopBenchmark.class"
+
   forkEvery 1
 
   systemProperty 'TEST_HOSTS', project.findProperty('hosts')


### PR DESCRIPTION
NoopBenchmark has some fundamental issues that make it fail constantly.
In recent testing, it passed significantly more often that it has been
in Apache Geode CI, so it needs to be excluded until it can be fixed.