### PR TITLE
Enabling logging for the geode-benchmarks

### DIFF
--- a/geode-benchmarks/build.gradle
+++ b/geode-benchmarks/build.gradle
@@ -42,6 +42,7 @@ dependencies {
   implementation(project(':harness'))
 
   implementation(group: 'org.apache.geode', name: 'geode-core', version: geodeVersion)
+  implementation(group: 'org.apache.geode', name: 'geode-log4j', version: geodeVersion)
 
   // Required for missing dependency on geode-core.
   runtime(group: 'org.eclipse.jetty', name: 'jetty-webapp', version: '9.4.12.v20180830')


### PR DESCRIPTION
The benchmarks we not logging any of the geode logs, they reported "ERROR
StatusLogger No Log4j 2 configuration file found."

I believe this was broken when we switched to having geode-log4j as a separate
module. Adding that module in as a dependency, which reenabled standard geode
logging.