### PR TITLE
Enable geode-benchmarks to run with only servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,20 @@ public class PutTask extends BenchmarkDriverAdapter implements Serializable {
 }
 ```
 
+## cluster topology
+
+The default topology is client/server.  Several tests support being run in a cluster topology
+where work is done directly in the servers and no client caches exist.  To enable this,
+specify `-PwithClusterTopology`.
+
+Tests that support this topology are
+
+ReplicatedPutBenchmark
+ReplicatedGetBenchmark
+PartitionedPutBenchmark
+PartitionedGetBenchmark
+
+
 ## SNI
 
 On AWS, you can run any benchmark on a topology that routes all client-server communication through an SNI proxy (HAproxy).

--- a/geode-benchmarks/build.gradle
+++ b/geode-benchmarks/build.gradle
@@ -93,6 +93,7 @@ task benchmark(type: Test) {
   }
   systemProperty 'withSsl', project.hasProperty('withSsl')
   systemProperty 'withSniProxy', project.hasProperty('withSniProxy')
+  systemProperty 'withClusterTopology', project.hasProperty('withSniProxy')
   systemProperty 'withSecurityManager', project.hasProperty('withSecurityManager')
   systemProperty 'benchmark.profiler.argument', project.findProperty('benchmark.profiler.argument')
 

--- a/geode-benchmarks/build.gradle
+++ b/geode-benchmarks/build.gradle
@@ -93,7 +93,7 @@ task benchmark(type: Test) {
   }
   systemProperty 'withSsl', project.hasProperty('withSsl')
   systemProperty 'withSniProxy', project.hasProperty('withSniProxy')
-  systemProperty 'withClusterTopology', project.hasProperty('withSniProxy')
+  systemProperty 'withClusterTopology', project.hasProperty('withClusterTopology')
   systemProperty 'withSecurityManager', project.hasProperty('withSecurityManager')
   systemProperty 'benchmark.profiler.argument', project.findProperty('benchmark.profiler.argument')
 

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/GetTask.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/GetTask.java
@@ -24,9 +24,9 @@ import org.yardstickframework.BenchmarkConfiguration;
 import org.yardstickframework.BenchmarkDriverAdapter;
 
 import org.apache.geode.benchmark.LongRange;
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.Region;
-import org.apache.geode.cache.client.ClientCache;
-import org.apache.geode.cache.client.ClientCacheFactory;
 
 /**
  * Task workload to perform get operations on keys within 0
@@ -46,7 +46,7 @@ public class GetTask extends BenchmarkDriverAdapter implements Serializable {
   public void setUp(BenchmarkConfiguration cfg) throws Exception {
     super.setUp(cfg);
 
-    final ClientCache cache = ClientCacheFactory.getAnyInstance();
+    final Cache cache = CacheFactory.getAnyInstance();
     region = cache.getRegion("region");
   }
 

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/PrePopulateRegion.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/PrePopulateRegion.java
@@ -66,8 +66,8 @@ public class PrePopulateRegion implements Task {
     final int numServers = context.getHostsIDsForRole(SERVER.name()).size();
     final int numClients = context.getHostsIDsForRole(CLIENT.name()).size();
     final int jvmID = context.getJvmID();
-    final int numWorkers = numClients>0? numClients : numServers;
-    final int workerIndex = numClients>0? jvmID - numLocators - numServers: jvmID - numLocators;
+    final int numWorkers = numClients > 0 ? numClients : numServers;
+    final int workerIndex = numClients > 0 ? jvmID - numLocators - numServers : jvmID - numLocators;
 
     run(region, keyRangeToPrepopulate.sliceFor(numWorkers, workerIndex));
   }

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/PutTask.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/PutTask.java
@@ -25,9 +25,9 @@ import org.yardstickframework.BenchmarkConfiguration;
 import org.yardstickframework.BenchmarkDriverAdapter;
 
 import org.apache.geode.benchmark.LongRange;
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.Region;
-import org.apache.geode.cache.client.ClientCache;
-import org.apache.geode.cache.client.ClientCacheFactory;
 
 public class PutTask extends BenchmarkDriverAdapter implements Serializable {
 
@@ -42,7 +42,7 @@ public class PutTask extends BenchmarkDriverAdapter implements Serializable {
   @Override
   public void setUp(BenchmarkConfiguration cfg) throws Exception {
     super.setUp(cfg);
-    ClientCache cache = ClientCacheFactory.getAnyInstance();
+    Cache cache = CacheFactory.getAnyInstance();
     region = cache.getRegion("region");
   }
 

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/GeodeBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/GeodeBenchmark.java
@@ -19,6 +19,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 
 import org.apache.geode.benchmark.topology.ClientServerTopology;
 import org.apache.geode.benchmark.topology.ClientServerTopologyWithSNIProxy;
+import org.apache.geode.benchmark.topology.ClusterTopology;
 import org.apache.geode.perftest.TestConfig;
 
 public class GeodeBenchmark {
@@ -45,11 +46,20 @@ public class GeodeBenchmark {
     config.durationSeconds(BENCHMARK_DURATION);
     config.threads(THREADS);
 
-    final String sniProp = System.getProperty("withSniProxy");
-    final boolean doSni = sniProp != null && !sniProp.equals("false");
+    String prop = System.getProperty("withSniProxy");
+    final boolean withSniProxy = prop != null && !prop.equals("false");
 
-    if (doSni) {
+    prop = System.getProperty("withClusterTopology");
+    final boolean withClusterTopology = prop != null && !prop.equals("false");
+
+    if (withSniProxy && withClusterTopology) {
+      throw new UnsupportedOperationException(
+          "The configuration withSniProxy plus withClusterTopology is not currently supported");
+    }
+    if (withSniProxy) {
       ClientServerTopologyWithSNIProxy.configure(config);
+    } else if (withClusterTopology) {
+      ClusterTopology.configure(config);
     } else {
       ClientServerTopology.configure(config);
     }

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/GeodeBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/GeodeBenchmark.java
@@ -46,11 +46,8 @@ public class GeodeBenchmark {
     config.durationSeconds(BENCHMARK_DURATION);
     config.threads(THREADS);
 
-    String prop = System.getProperty("withSniProxy");
-    final boolean withSniProxy = prop != null && !prop.equals("false");
-
-    prop = System.getProperty("withClusterTopology");
-    final boolean withClusterTopology = prop != null && !prop.equals("false");
+    final boolean withSniProxy = Boolean.getBoolean("withSniProxy");
+    final boolean withClusterTopology = Boolean.getBoolean("withClusterTopology");
 
     if (withSniProxy && withClusterTopology) {
       throw new UnsupportedOperationException(

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedGetBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedGetBenchmark.java
@@ -56,9 +56,14 @@ public class PartitionedGetBenchmark implements PerformanceTest {
   public TestConfig configure() {
     TestConfig config = GeodeBenchmark.createConfig();
     before(config, new CreatePartitionedRegion(), SERVER);
-    before(config, new CreateClientProxyRegion(), CLIENT);
-    before(config, new PrePopulateRegion(keyRange), CLIENT);
-    workload(config, new GetTask(keyRange), CLIENT);
+    if (config.getRoles().containsKey(CLIENT)) {
+      before(config, new CreateClientProxyRegion(), CLIENT);
+      before(config, new PrePopulateRegion(keyRange), CLIENT);
+      workload(config, new GetTask(keyRange), CLIENT);
+    } else {
+      before(config, new PrePopulateRegion(keyRange), CLIENT);
+      workload(config, new GetTask(keyRange), CLIENT);
+    }
     return config;
 
   }

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedGetBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedGetBenchmark.java
@@ -61,8 +61,8 @@ public class PartitionedGetBenchmark implements PerformanceTest {
       before(config, new PrePopulateRegion(keyRange), CLIENT);
       workload(config, new GetTask(keyRange), CLIENT);
     } else {
-      before(config, new PrePopulateRegion(keyRange), CLIENT);
-      workload(config, new GetTask(keyRange), CLIENT);
+      before(config, new PrePopulateRegion(keyRange), SERVER);
+      workload(config, new GetTask(keyRange), SERVER);
     }
     return config;
 

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedPutBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/PartitionedPutBenchmark.java
@@ -56,9 +56,14 @@ public class PartitionedPutBenchmark implements PerformanceTest {
     TestConfig config = GeodeBenchmark.createConfig();
 
     before(config, new CreatePartitionedRegion(), SERVER);
-    before(config, new CreateClientProxyRegion(), CLIENT);
-    before(config, new PrePopulateRegion(keyRange), CLIENT);
-    workload(config, new PutTask(keyRange), CLIENT);
+    if (config.getRoles().containsKey(CLIENT)) {
+      before(config, new CreateClientProxyRegion(), CLIENT);
+      before(config, new PrePopulateRegion(keyRange), CLIENT);
+      workload(config, new PutTask(keyRange), CLIENT);
+    } else {
+      before(config, new PrePopulateRegion(keyRange), SERVER);
+      workload(config, new PutTask(keyRange), SERVER);
+    }
     return config;
   }
 }

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/ReplicatedGetBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/ReplicatedGetBenchmark.java
@@ -56,9 +56,14 @@ public class ReplicatedGetBenchmark implements PerformanceTest {
   public TestConfig configure() {
     TestConfig config = GeodeBenchmark.createConfig();
     before(config, new CreateReplicatedRegion(), SERVER);
-    before(config, new CreateClientProxyRegion(), CLIENT);
-    before(config, new PrePopulateRegion(keyRange), CLIENT);
-    workload(config, new GetTask(keyRange), CLIENT);
+    if (config.getRoles().containsKey(CLIENT)) {
+      before(config, new CreateClientProxyRegion(), CLIENT);
+      before(config, new PrePopulateRegion(keyRange), CLIENT);
+      workload(config, new GetTask(keyRange), CLIENT);
+    } else {
+      before(config, new PrePopulateRegion(keyRange), SERVER);
+      workload(config, new GetTask(keyRange), SERVER);
+    }
     return config;
 
   }

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/ReplicatedPutBenchmark.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tests/ReplicatedPutBenchmark.java
@@ -55,9 +55,14 @@ public class ReplicatedPutBenchmark implements PerformanceTest {
   public TestConfig configure() {
     TestConfig config = GeodeBenchmark.createConfig();
     before(config, new CreateReplicatedRegion(), SERVER);
-    before(config, new CreateClientProxyRegion(), CLIENT);
-    before(config, new PrePopulateRegion(keyRange), CLIENT);
-    workload(config, new PutTask(keyRange), CLIENT);
+    if (config.getRoles().containsKey(CLIENT)) {
+      before(config, new CreateClientProxyRegion(), CLIENT);
+      before(config, new PrePopulateRegion(keyRange), CLIENT);
+      workload(config, new PutTask(keyRange), CLIENT);
+    } else {
+      before(config, new PrePopulateRegion(keyRange), SERVER);
+      workload(config, new PutTask(keyRange), SERVER);
+    }
     return config;
 
   }

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/topology/ClusterTopology.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/topology/ClusterTopology.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.benchmark.topology;
+
+import static org.apache.geode.benchmark.Config.before;
+import static org.apache.geode.benchmark.Config.role;
+import static org.apache.geode.benchmark.parameters.Utils.addToTestConfig;
+import static org.apache.geode.benchmark.topology.Ports.LOCATOR_PORT;
+import static org.apache.geode.benchmark.topology.Roles.LOCATOR;
+import static org.apache.geode.benchmark.topology.Roles.SERVER;
+
+import org.apache.geode.benchmark.parameters.GcLoggingParameters;
+import org.apache.geode.benchmark.parameters.GcParameters;
+import org.apache.geode.benchmark.parameters.HeapParameters;
+import org.apache.geode.benchmark.parameters.JvmParameters;
+import org.apache.geode.benchmark.parameters.ProfilerParameters;
+import org.apache.geode.benchmark.tasks.StartLocator;
+import org.apache.geode.benchmark.tasks.StartServer;
+import org.apache.geode.perftest.TestConfig;
+
+public class ClusterTopology {
+  private static final int NUM_LOCATORS = 1;
+  private static final int NUM_SERVERS = 3;
+  private static final String WITH_SSL_ARGUMENT = "-DwithSsl=true";
+  private static final String WITH_SECURITY_MANAGER_ARGUMENT = "-DwithSecurityManager=true";
+
+  public static void configure(TestConfig config) {
+    role(config, LOCATOR, NUM_LOCATORS);
+    role(config, SERVER, NUM_SERVERS);
+
+    JvmParameters.configure(config);
+    HeapParameters.configure(config);
+    GcLoggingParameters.configure(config);
+    GcParameters.configure(config);
+    ProfilerParameters.configure(config);
+
+    addToTestConfig(config, "withSsl", WITH_SSL_ARGUMENT);
+    addToTestConfig(config, "withSecurityManager", WITH_SECURITY_MANAGER_ARGUMENT);
+
+    before(config, new StartLocator(LOCATOR_PORT), LOCATOR);
+    before(config, new StartServer(LOCATOR_PORT), SERVER);
+  }
+
+}

--- a/geode-benchmarks/src/test/java/org/apache/geode/benchmark/tests/GeodeBenchmarkTest.java
+++ b/geode-benchmarks/src/test/java/org/apache/geode/benchmark/tests/GeodeBenchmarkTest.java
@@ -18,10 +18,10 @@
 package org.apache.geode.benchmark.tests;
 
 import static org.apache.geode.benchmark.topology.Ports.LOCATOR_PORT;
+import static org.apache.geode.benchmark.topology.Roles.CLIENT;
 import static org.apache.geode.benchmark.topology.Roles.PROXY;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,46 +36,66 @@ import org.apache.geode.perftest.TestStep;
  */
 class GeodeBenchmarkTest {
 
+  public static final String WITH_CLUSTER_TOPOLOGY = "withClusterTopology";
+  public static final String WITH_SNI_PROXY = "withSniProxy";
   private TestConfig config;
   private TestStep startProxyStep;
 
   @BeforeEach
   public void beforeEach() {
+    System.clearProperty(WITH_SNI_PROXY);
+    System.clearProperty(WITH_CLUSTER_TOPOLOGY);
     startProxyStep =
         new TestStep(new StartSniProxy(LOCATOR_PORT), new String[] {PROXY.name()});
   }
 
-  @AfterAll
-  public static void afterAll() {
-    System.clearProperty("withSniProxy");
-  }
-
   @Test
   public void withoutSniProxy() {
-    System.clearProperty("withSniProxy");
+    System.clearProperty(WITH_SNI_PROXY);
     config = GeodeBenchmark.createConfig();
     assertThat(config.getBefore()).doesNotContain(startProxyStep);
   }
 
   @Test
   public void withSniProxyFalse() {
-    System.setProperty("withSniProxy", "false");
+    System.setProperty(WITH_SNI_PROXY, "false");
     config = GeodeBenchmark.createConfig();
     assertThat(config.getBefore()).doesNotContain(startProxyStep);
   }
 
   @Test
   public void withSniProxyTrue() {
-    System.setProperty("withSniProxy", "true");
+    System.setProperty(WITH_SNI_PROXY, "true");
     config = GeodeBenchmark.createConfig();
     assertThat(config.getBefore()).contains(startProxyStep);
   }
 
   @Test
   public void withSniProxyNotLowercaseFalse() {
-    System.setProperty("withSniProxy", "AnythING");
+    System.setProperty(WITH_SNI_PROXY, "AnythING");
     config = GeodeBenchmark.createConfig();
     assertThat(config.getBefore()).contains(startProxyStep);
+  }
+
+  @Test
+  public void withClusterTopologyFalse() {
+    System.setProperty(WITH_CLUSTER_TOPOLOGY, "false");
+    config = GeodeBenchmark.createConfig();
+    assertThat(config.getRoles().get(CLIENT.name())).isNotNull();
+  }
+
+  @Test
+  public void withClusterTopologyTrue() {
+    System.setProperty(WITH_CLUSTER_TOPOLOGY, "true");
+    config = GeodeBenchmark.createConfig();
+    assertThat(config.getRoles().get(CLIENT.name())).isNull();
+  }
+
+  @Test
+  public void withClusterTopologyNotLowercaseFalse() {
+    System.setProperty(WITH_CLUSTER_TOPOLOGY, "AnythING");
+    config = GeodeBenchmark.createConfig();
+    assertThat(config.getRoles().get(CLIENT.name())).isNull();
   }
 
 }

--- a/geode-benchmarks/src/test/java/org/apache/geode/benchmark/tests/GeodeBenchmarkTest.java
+++ b/geode-benchmarks/src/test/java/org/apache/geode/benchmark/tests/GeodeBenchmarkTest.java
@@ -51,7 +51,7 @@ class GeodeBenchmarkTest {
   }
 
   @AfterAll
-  public void afterAll() {
+  public static void afterAll() {
     System.clearProperty(WITH_SNI_PROXY);
     System.clearProperty(WITH_CLUSTER_TOPOLOGY);
   }

--- a/geode-benchmarks/src/test/java/org/apache/geode/benchmark/tests/GeodeBenchmarkTest.java
+++ b/geode-benchmarks/src/test/java/org/apache/geode/benchmark/tests/GeodeBenchmarkTest.java
@@ -22,6 +22,7 @@ import static org.apache.geode.benchmark.topology.Roles.CLIENT;
 import static org.apache.geode.benchmark.topology.Roles.PROXY;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,6 +48,12 @@ class GeodeBenchmarkTest {
     System.clearProperty(WITH_CLUSTER_TOPOLOGY);
     startProxyStep =
         new TestStep(new StartSniProxy(LOCATOR_PORT), new String[] {PROXY.name()});
+  }
+
+  @AfterAll
+  public void afterAll() {
+    System.clearProperty(WITH_SNI_PROXY);
+    System.clearProperty(WITH_CLUSTER_TOPOLOGY);
   }
 
   @Test

--- a/geode-benchmarks/src/test/java/org/apache/geode/benchmark/tests/GeodeBenchmarkTest.java
+++ b/geode-benchmarks/src/test/java/org/apache/geode/benchmark/tests/GeodeBenchmarkTest.java
@@ -78,13 +78,6 @@ class GeodeBenchmarkTest {
   }
 
   @Test
-  public void withSniProxyNotLowercaseFalse() {
-    System.setProperty(WITH_SNI_PROXY, "AnythING");
-    config = GeodeBenchmark.createConfig();
-    assertThat(config.getBefore()).contains(startProxyStep);
-  }
-
-  @Test
   public void withClusterTopologyFalse() {
     System.setProperty(WITH_CLUSTER_TOPOLOGY, "false");
     config = GeodeBenchmark.createConfig();
@@ -94,13 +87,6 @@ class GeodeBenchmarkTest {
   @Test
   public void withClusterTopologyTrue() {
     System.setProperty(WITH_CLUSTER_TOPOLOGY, "true");
-    config = GeodeBenchmark.createConfig();
-    assertThat(config.getRoles().get(CLIENT.name())).isNull();
-  }
-
-  @Test
-  public void withClusterTopologyNotLowercaseFalse() {
-    System.setProperty(WITH_CLUSTER_TOPOLOGY, "AnythING");
     config = GeodeBenchmark.createConfig();
     assertThat(config.getRoles().get(CLIENT.name())).isNull();
   }

--- a/harness/src/main/java/org/apache/geode/perftest/analysis/Analyzer.java
+++ b/harness/src/main/java/org/apache/geode/perftest/analysis/Analyzer.java
@@ -83,8 +83,12 @@ public class Analyzer {
       for (BenchmarkRunResult.ProbeResult probeResult : benchmarkResult.probeResults) {
         if (isNaN(probeResult.baseline) || isNaN(probeResult.test)) {
           errorMessage.append("BENCHMARK FAILED: ").append(benchmarkResult.name)
-              .append(" missing result file.\n");
+              .append("probeResult=").append(probeResult.description)
+              .append("; baseline=").append(probeResult.baseline)
+              .append("; test=").append(probeResult.test)
+              .append("\n");
           writer.append(benchmarkResult.name + "\n");
+          System.out.print(errorMessage);
         } else if (probeResult.description.equals("average latency")) {
           if (probeResult.getDifference() > 0) {
             isHighWaterCandidate = false;


### PR DESCRIPTION
In order to vet the performance of changes in GEODE-8349 I've added a new client-less topology and converted a few put/get tests to optionally use it.

The topology is selected with "-PwithClusterTopology"

Partitioned and Replicated Get and Put benchmarks have been updated to support this topology.  I had to modify them to assign workloads to Servers if no Clients are available.