### PR TITLE
revert change to output file naming

### DIFF
--- a/infrastructure/scripts/aws/run_against_baseline.sh
+++ b/infrastructure/scripts/aws/run_against_baseline.sh
@@ -153,7 +153,11 @@ if [ -z "${TAG}" ]; then
   exit 1
 fi
 
-OUTPUT="${OUTPUT:-output-${DATE}-${TAG}}"
+if [ ! -z "${OUTPUT}" ]; then
+  OUTPUT="${OUTPUT}-"
+fi
+
+OUTPUT="${OUTPUT}output-${DATE}-${TAG}"
 
 set -x
 if ! [[ "$OUTPUT" = /* ]]; then


### PR DESCRIPTION
reverting because the change to output file naming caused CI to not check the correct output for retried test runs.