### PR TITLE
Prevent Travis build timeout

### DIFF
--- a/geode-benchmarks/build.gradle
+++ b/geode-benchmarks/build.gradle
@@ -68,7 +68,12 @@ compileJava {
   options.deprecation = true
 }
 
-test{ useJUnitPlatform() }
+test{
+  afterTest { desc, result ->
+    logger.quiet "Executing test ${desc.className}.${desc.name} with result: ${result.resultType}"
+  }
+  useJUnitPlatform()
+}
 
 task benchmark(type: Test) {
   if (project.hasProperty('testJVM') && !testJVM.trim().isEmpty()) {


### PR DESCRIPTION
- Add output after each test completes, as Travis declares a task hung
if no output is written for 10 minutes, which is longer than the build
and tests take to complete

Authored-by: Donal Evans <doevans@vmware.com>