### PR TITLE
Disable P2pPartitionedPutLongBenchmark

### DIFF
--- a/geode-benchmarks/build.gradle
+++ b/geode-benchmarks/build.gradle
@@ -86,6 +86,7 @@ task benchmark(type: Test) {
   testLogging { exceptionFormat = 'full' }
 
   exclude "**/NoopBenchmark.class"
+  exclude "**/P2pPartitionedPutLongBenchmark.class"
 
   forkEvery 1
   failFast = true


### PR DESCRIPTION
 - This benchmark is unstable and does not produce reliable results. See
GEODE-8950 for further details.

Authored-by: Donal Evans <doevans@vmware.com>