### PR TITLE
GEODE-9175: Logging progress of benchmarks as they are running

### DIFF
--- a/geode-benchmarks/build.gradle
+++ b/geode-benchmarks/build.gradle
@@ -73,6 +73,10 @@ test{
     logger.quiet "Executing test ${desc.className}.${desc.name} with result: ${result.resultType}"
   }
   useJUnitPlatform()
+  systemProperty 'org.slf4j.simpleLogger.showDateTime', 'true'
+  systemProperty 'org.slf4j.simpleLogger.dateTimeFormat', 'yyyy-MM-dd HH:mm:ss.SSS'
+  systemProperty 'org.slf4j.simpleLogger.showThreadNam', 'false'
+  systemProperty 'org.slf4j.simpleLogger.showShortLogName', 'true'
 }
 
 task benchmark(type: Test) {
@@ -83,7 +87,10 @@ task benchmark(type: Test) {
   testClassesDirs = project.sourceSets.main.output.classesDirs
   classpath = project.sourceSets.main.runtimeClasspath
   useJUnitPlatform()
-  testLogging { exceptionFormat = 'full' }
+  testLogging {
+    exceptionFormat = 'full'
+    showStandardStreams = true
+  }
 
   exclude "**/NoopBenchmark.class"
   exclude "**/P2pPartitionedPutLongBenchmark.class"
@@ -91,6 +98,10 @@ task benchmark(type: Test) {
   forkEvery 1
   failFast = true
 
+  systemProperty 'org.slf4j.simpleLogger.showDateTime', 'true'
+  systemProperty 'org.slf4j.simpleLogger.dateTimeFormat', 'yyyy-MM-dd HH:mm:ss.SSS'
+  systemProperty 'org.slf4j.simpleLogger.showThreadName', 'false'
+  systemProperty 'org.slf4j.simpleLogger.showShortLogName', 'true'
   systemProperty 'TEST_HOSTS', project.findProperty('hosts')
   systemProperty 'TEST_METADATA', project.findProperty('metadata')
   systemProperty 'OUTPUT_DIR', outputDir

--- a/harness/src/main/java/org/apache/geode/perftest/TestContext.java
+++ b/harness/src/main/java/org/apache/geode/perftest/TestContext.java
@@ -53,5 +53,10 @@ public interface TestContext extends Serializable {
   Object getAttribute(String key);
 
 
-
+  /**
+   * Print a log message to the terminal about the progress of a test task
+   *
+   * @param progress The progress message to display
+   */
+  void logProgress(String progress);
 }

--- a/harness/src/main/java/org/apache/geode/perftest/infrastructure/local/LocalInfrastructure.java
+++ b/harness/src/main/java/org/apache/geode/perftest/infrastructure/local/LocalInfrastructure.java
@@ -34,6 +34,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 
 import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.geode.perftest.infrastructure.Infrastructure;
 
@@ -42,6 +44,7 @@ import org.apache.geode.perftest.infrastructure.Infrastructure;
  * on the local computer, in their own working directories.
  */
 public class LocalInfrastructure implements Infrastructure {
+  private static final Logger logger = LoggerFactory.getLogger(LocalInfrastructure.class);
 
   private final Set<LocalNode> nodes = new LinkedHashSet<>();
   private final List<Process> processList = new CopyOnWriteArrayList<>();
@@ -66,7 +69,7 @@ public class LocalInfrastructure implements Infrastructure {
     builder.inheritIO();
     builder.directory(((LocalNode) node).getWorkingDir());
 
-    System.out.println(String.format("Launching %s>%s", ((LocalNode) node).getWorkingDir(),
+    logger.debug(String.format("Launching %s>%s", ((LocalNode) node).getWorkingDir(),
         String.join(" ", shellCommand)));
     Process process = builder.start();
     processList.add(process);

--- a/harness/src/main/java/org/apache/geode/perftest/infrastructure/ssh/QuietSshLoggingConfig.java
+++ b/harness/src/main/java/org/apache/geode/perftest/infrastructure/ssh/QuietSshLoggingConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.perftest.infrastructure.ssh;
+
+import net.schmizz.sshj.DefaultConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.NOPLogger;
+
+class QuietSshLoggingConfig extends DefaultConfig {
+  private static final Logger logger = LoggerFactory.getLogger(QuietSshLoggingConfig.class);
+
+  @Override
+  public net.schmizz.sshj.common.LoggerFactory getLoggerFactory() {
+    if (logger.isDebugEnabled()) {
+      return super.getLoggerFactory();
+    } else {
+      return new NOPLoggerFactory();
+    }
+  }
+
+  private static class NOPLoggerFactory implements net.schmizz.sshj.common.LoggerFactory {
+    @Override
+    public Logger getLogger(String name) {
+      return NOPLogger.NOP_LOGGER;
+    }
+
+    @Override
+    public Logger getLogger(Class<?> clazz) {
+      return NOPLogger.NOP_LOGGER;
+    }
+  }
+}

--- a/harness/src/main/java/org/apache/geode/perftest/infrastructure/ssh/SshInfrastructure.java
+++ b/harness/src/main/java/org/apache/geode/perftest/infrastructure/ssh/SshInfrastructure.java
@@ -37,7 +37,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import net.schmizz.sshj.Config;
-import net.schmizz.sshj.DefaultConfig;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.connection.channel.direct.Session;
 import net.schmizz.sshj.connection.channel.direct.Signal;
@@ -54,7 +53,7 @@ public class SshInfrastructure implements Infrastructure {
   private final Set<SshNode> hosts;
   private final String user;
   private final int port;
-  public static final Config CONFIG = new DefaultConfig();
+  public static final Config CONFIG = new QuietSshLoggingConfig();
   private ExecutorService streamReaderThreadPool = Executors.newCachedThreadPool();
 
   public SshInfrastructure(Collection<String> hosts, String user) {
@@ -87,7 +86,7 @@ public class SshInfrastructure implements Infrastructure {
     try (final SSHClient client = getSSHClient(node.getAddress());
         final Session session = client.startSession()) {
       final String script = "'" + String.join("' '", shellCommand) + "'";
-      logger.info("Executing {} on {}", script, node.getAddress());
+      logger.debug("Executing {} on {}", script, node.getAddress());
       try (final Session.Command cmd = session.exec(script)) {
         final CompletableFuture<Void> copyStdout =
             copyStreamAsynchronously(cmd.getInputStream(), System.out);
@@ -170,7 +169,7 @@ public class SshInfrastructure implements Infrastructure {
           }
 
           for (File file : files) {
-            logger.info("Copying " + file + " to " + address);
+            logger.debug("Copying " + file + " to " + address);
             client.newSCPFileTransfer().upload(new FileSystemFile(file), destDir);
           }
         } catch (IOException e) {
@@ -209,4 +208,5 @@ public class SshInfrastructure implements Infrastructure {
       return host;
     }
   }
+
 }

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/JVMLauncher.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/JVMLauncher.java
@@ -89,6 +89,7 @@ class JVMLauncher {
     command.add("-D" + RemoteJVMFactory.RMI_HOST + "=" + rmiHost);
     command.add("-D" + RemoteJVMFactory.RMI_PORT_PROPERTY + "=" + rmiPort);
     command.add("-D" + RemoteJVMFactory.JVM_ID + "=" + jvmConfig.getId());
+    command.add("-D" + RemoteJVMFactory.ROLE + "=" + jvmConfig.getRole());
     command.add("-D" + RemoteJVMFactory.OUTPUT_DIR + "=" + jvmConfig.getOutputDir());
 
     if (jvmConfig.getJvmArgs().contains("-DwithSsl=true")) {

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/RemoteJVMFactory.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/RemoteJVMFactory.java
@@ -67,6 +67,7 @@ public class RemoteJVMFactory {
   public static final String RMI_PORT_PROPERTY = "RMI_PORT";
   public static final String CONTROLLER = "CONTROLLER";
   public static final String OUTPUT_DIR = "OUTPUT_DIR";
+  public static final String ROLE = "ROLE";
   public static final String JVM_ID = "JVM_ID";
   public static final int RMI_PORT = 33333;
   private static final String CLASSPATH = System.getProperty("java.class.path");
@@ -161,7 +162,7 @@ public class RemoteJVMFactory {
     X509Certificate[] chain = new X509Certificate[1];
     chain[0] = keyGen.getSelfCertificate(new X500Name("CN=ROOT"), DAYS.toSeconds(365));
 
-    logger.info("Certificate : {}", chain[0]);
+    logger.debug("Certificate : {}", chain[0]);
 
     KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
     ks.load(null, null);

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/ChildJVM.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/ChildJVM.java
@@ -53,6 +53,7 @@ public class ChildJVM {
       String RMI_PORT = system.getProperty(RemoteJVMFactory.RMI_PORT_PROPERTY);
       String OUTPUT_DIR = system.getProperty(RemoteJVMFactory.OUTPUT_DIR);
       int id = system.getInteger(RemoteJVMFactory.JVM_ID);
+      String role = system.getProperty(RemoteJVMFactory.ROLE);
 
       if (RMI_HOST == null || RMI_PORT == null || OUTPUT_DIR == null) {
         throw new IllegalStateException(
@@ -68,7 +69,8 @@ public class ChildJVM {
             .lookup("//" + RMI_HOST + ":" + RMI_PORT + "/" + RemoteJVMFactory.CONTROLLER);
 
         SharedContext sharedContext = controller.getsharedContext();
-        DefaultTestContext context = new DefaultTestContext(sharedContext, outputDir, id);
+        DefaultTestContext context =
+            new DefaultTestContext(sharedContext, outputDir, id, role, controller);
 
         Worker worker = new Worker(context);
 

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/Controller.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/Controller.java
@@ -29,6 +29,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.geode.perftest.Task;
 import org.apache.geode.perftest.runner.SharedContext;
 
@@ -36,6 +39,7 @@ import org.apache.geode.perftest.runner.SharedContext;
  * RMI object that lives on the main controller JVM
  */
 public class Controller extends UnicastRemoteObject implements ControllerRemote {
+  Logger logger = LoggerFactory.getLogger(Controller.class);
   private final Registry registry;
   private final SharedContext context;
   private final Map<Integer, WorkerRemote> workers = new ConcurrentHashMap<>();
@@ -69,6 +73,11 @@ public class Controller extends UnicastRemoteObject implements ControllerRemote 
   @Override
   public boolean ping() throws RemoteException {
     return !isClosed;
+  }
+
+  @Override
+  public void logProgress(String progress) throws RemoteException {
+    logger.info(progress);
   }
 
   @Override

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/ControllerRemote.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/rmi/ControllerRemote.java
@@ -28,5 +28,7 @@ public interface ControllerRemote extends Remote {
 
   boolean ping() throws RemoteException;
 
+  void logProgress(String progress) throws RemoteException;
+
   SharedContext getsharedContext() throws RemoteException;
 }

--- a/harness/src/main/java/org/apache/geode/perftest/runner/DefaultTestContext.java
+++ b/harness/src/main/java/org/apache/geode/perftest/runner/DefaultTestContext.java
@@ -19,21 +19,28 @@ package org.apache.geode.perftest.runner;
 
 import java.io.File;
 import java.net.InetAddress;
+import java.rmi.RemoteException;
 import java.util.Set;
 import java.util.TreeMap;
 
 import org.apache.geode.perftest.TestContext;
+import org.apache.geode.perftest.jvms.rmi.ControllerRemote;
 
 public class DefaultTestContext implements TestContext {
 
   private SharedContext sharedContext;
   private File outputDir;
+  private String role;
+  private ControllerRemote controller;
   private int jvmID;
   TreeMap<String, Object> attributeMap;
 
-  public DefaultTestContext(SharedContext sharedContext, File outputDir, int jvmID) {
+  public DefaultTestContext(SharedContext sharedContext, File outputDir, int jvmID,
+      String role, ControllerRemote controller) {
     this.sharedContext = sharedContext;
     this.outputDir = outputDir;
+    this.role = role;
+    this.controller = controller;
     attributeMap = new TreeMap<>();
     this.jvmID = jvmID;
   }
@@ -66,5 +73,15 @@ public class DefaultTestContext implements TestContext {
   @Override
   public File getOutputDir() {
     return outputDir;
+  }
+
+  @Override
+  public void logProgress(String progress) {
+    try {
+      controller.logProgress(String.format("%s-%02d: %s", role, jvmID, progress));
+    } catch (RemoteException e) {
+      throw new IllegalStateException("Controller connection lost", e);
+    }
+
   }
 }

--- a/harness/src/main/java/org/apache/geode/perftest/runner/DefaultTestRunner.java
+++ b/harness/src/main/java/org/apache/geode/perftest/runner/DefaultTestRunner.java
@@ -132,7 +132,7 @@ public class DefaultTestRunner implements TestRunner {
       // Close before copy otherwise logs, stats, and profiles are incomplete or missing.
       remoteJVMs.closeController();
 
-      logger.info("Copying results...");
+      logger.info("Copying results to {}", benchmarkOutput);
       remoteJVMs.copyResults(benchmarkOutput);
 
       remoteJVMs.closeInfra();

--- a/harness/src/main/java/org/apache/geode/perftest/yardstick/TestDoneProbe.java
+++ b/harness/src/main/java/org/apache/geode/perftest/yardstick/TestDoneProbe.java
@@ -20,6 +20,7 @@ package org.apache.geode.perftest.yardstick;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.yardstickframework.BenchmarkConfiguration;
 import org.yardstickframework.BenchmarkDriver;
@@ -30,8 +31,8 @@ class TestDoneProbe implements BenchmarkProbe {
 
   CountDownLatch done = new CountDownLatch(1);
 
-  public void await() throws InterruptedException {
-    done.await();
+  public boolean await(long time, TimeUnit unit) throws InterruptedException {
+    return done.await(time, unit);
   }
 
   @Override

--- a/harness/src/main/java/org/apache/geode/perftest/yardstick/YardstickTask.java
+++ b/harness/src/main/java/org/apache/geode/perftest/yardstick/YardstickTask.java
@@ -20,7 +20,9 @@ package org.apache.geode.perftest.yardstick;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import org.HdrHistogram.Histogram;
 import org.yardstickframework.BenchmarkConfiguration;
 import org.yardstickframework.BenchmarkDriver;
 import org.yardstickframework.BenchmarkProbe;
@@ -91,8 +93,11 @@ public class YardstickTask implements Task {
     benchmark.setUp(cfg);
 
     TestDoneProbe testDoneProbe = new TestDoneProbe();
+    final HdrHistogramProbe hdrHistogramProbe =
+        new HdrHistogramProbe(new HdrHistogramWriter(context.getOutputDir()));
+
     Collection<BenchmarkProbe> probes =
-        Arrays.asList(new HdrHistogramProbe(new HdrHistogramWriter(context.getOutputDir())),
+        Arrays.asList(hdrHistogramProbe,
             new ThroughputLatencyProbe(),
             new PercentileProbe(), new VmStatProbe(),
             testDoneProbe);
@@ -107,6 +112,35 @@ public class YardstickTask implements Task {
 
     runner.runBenchmark();
 
-    testDoneProbe.await();
+    Histogram lastHistogram = hdrHistogramProbe.getHistogram();
+    while (!testDoneProbe.await(10, TimeUnit.SECONDS)) {
+      boolean warmupFinished = hdrHistogramProbe.isWarmupFinished();
+      // Create a histogram for the previous 10 second window
+      Histogram histogram = hdrHistogramProbe.getHistogram();
+      Histogram currentHistogram = histogram.copy();
+      if (histogram.getStartTimeStamp() == lastHistogram.getStartTimeStamp()) {
+        currentHistogram.subtract(lastHistogram);
+        currentHistogram.setStartTimeStamp(lastHistogram.getEndTimeStamp());
+      }
+
+      String prefix = warmupFinished ? "WORK" : "WARMUP";
+
+      // Log the histogram
+      logProgress(context, prefix, currentHistogram);
+
+      // Capture the current histogram
+      lastHistogram = histogram;
+    }
+    logProgress(context, "TOTAL", hdrHistogramProbe.getHistogram());
+  }
+
+  private void logProgress(TestContext context, String prefix, Histogram histogram) {
+    double throughput = (((double) histogram.getTotalCount())
+        / (histogram.getEndTimeStamp() - histogram.getStartTimeStamp())) * 1000;
+    double meanLatency = histogram.getMean() / 1_000_000.0;
+    double percentile_99 = histogram.getValueAtPercentile(99) / 1_000_000.0;
+    context
+        .logProgress(String.format("%6s ops/sec: %10.2f, latency: %4.3f ms, 99%% latency: %4.3f ms",
+            prefix, throughput, meanLatency, percentile_99));
   }
 }

--- a/harness/src/main/java/org/apache/geode/perftest/yardstick/hdrhistogram/HdrHistogramProbe.java
+++ b/harness/src/main/java/org/apache/geode/perftest/yardstick/hdrhistogram/HdrHistogramProbe.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import org.HdrHistogram.Histogram;
@@ -56,6 +57,7 @@ public class HdrHistogramProbe implements BenchmarkExecutionAwareProbe, Benchmar
   private final Consumer<Histogram> histogramConsumer;
   private long[] startTimes;
   private Histogram[] histograms;
+  private AtomicBoolean warmUpFinished = new AtomicBoolean(false);
 
   public HdrHistogramProbe(Consumer<Histogram> histogramConsumer) {
     this(1, TimeUnit.HOURS.toNanos(5), 3, () -> System.nanoTime(), histogramConsumer);
@@ -116,7 +118,9 @@ public class HdrHistogramProbe implements BenchmarkExecutionAwareProbe, Benchmar
   @Override
   public Collection<BenchmarkProbePoint> points() {
     final Histogram aggregate = getHistogram();
-    reset();
+    if (warmUpFinished.compareAndSet(false, true)) {
+      reset();
+    }
 
     final double mean = aggregate.getMean();
     final long percentile99 = aggregate.getValueAtPercentile(99);
@@ -146,12 +150,16 @@ public class HdrHistogramProbe implements BenchmarkExecutionAwareProbe, Benchmar
 
   }
 
-  Histogram getHistogram() {
+  public Histogram getHistogram() {
     final Histogram aggregate = new Histogram(lower, upper, numDigits);
     for (final Histogram histogram : histograms) {
       aggregate.add(histogram);
     }
     aggregate.setEndTimeStamp(System.currentTimeMillis());
     return aggregate;
+  }
+
+  public boolean isWarmupFinished() {
+    return warmUpFinished.get();
   }
 }

--- a/harness/src/test/java/org/apache/geode/perftest/yardstick/YardstickTaskTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/yardstick/YardstickTaskTest.java
@@ -18,6 +18,7 @@
 package org.apache.geode.perftest.yardstick;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -30,6 +31,7 @@ import org.apache.geode.perftest.Task;
 import org.apache.geode.perftest.TestContext;
 import org.apache.geode.perftest.WorkloadConfig;
 import org.apache.geode.perftest.benchmarks.EmptyBenchmark;
+import org.apache.geode.perftest.jvms.rmi.ControllerRemote;
 import org.apache.geode.perftest.runner.DefaultTestContext;
 import org.apache.geode.perftest.yardstick.hdrhistogram.HdrHistogramWriter;
 
@@ -45,7 +47,8 @@ public class YardstickTaskTest {
     workloadConfig.threads(1);
     Task task = new YardstickTask(benchmark, workloadConfig);
     File outputDir = folder.toFile();
-    TestContext context = new DefaultTestContext(null, outputDir, 1, role, controller);
+    ControllerRemote controller = mock(ControllerRemote.class);
+    TestContext context = new DefaultTestContext(null, outputDir, 1, "role", controller);
     task.run(context);
 
     assertTrue(1 <= benchmark.getInvocations());

--- a/harness/src/test/java/org/apache/geode/perftest/yardstick/YardstickTaskTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/yardstick/YardstickTaskTest.java
@@ -45,7 +45,7 @@ public class YardstickTaskTest {
     workloadConfig.threads(1);
     Task task = new YardstickTask(benchmark, workloadConfig);
     File outputDir = folder.toFile();
-    TestContext context = new DefaultTestContext(null, outputDir, 1);
+    TestContext context = new DefaultTestContext(null, outputDir, 1, role, controller);
     task.run(context);
 
     assertTrue(1 <= benchmark.getInvocations());

--- a/infrastructure/scripts/aws/run_tests.sh
+++ b/infrastructure/scripts/aws/run_tests.sh
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -x -e -o pipefail
+set -e -o pipefail
 
 DEFAULT_BENCHMARK_REPO='https://github.com/apache/geode-benchmarks'
 BENCHMARK_REPO=${DEFAULT_BENCHMARK_REPO}
@@ -222,6 +222,7 @@ remoteShell \
 
 mkdir -p ${OUTPUT}
 
-scp ${SSH_OPTIONS} -r geode@${FIRST_INSTANCE}:geode-benchmarks/geode-benchmarks/build/reports ${OUTPUT}/reports
+scp ${SSH_OPTIONS} -q -r geode@${FIRST_INSTANCE}:geode-benchmarks/geode-benchmarks/build/reports ${OUTPUT}/reports
 BENCHMARK_DIRECTORY="$(remoteShell ls -l geode-benchmarks/geode-benchmarks/build/ | grep benchmark | awk 'NF>1{print $NF}')"
-scp ${SSH_OPTIONS} -r geode@${FIRST_INSTANCE}:geode-benchmarks/geode-benchmarks/build/${BENCHMARK_DIRECTORY} ${OUTPUT}
+scp ${SSH_OPTIONS} -q -r geode@${FIRST_INSTANCE}:geode-benchmarks/geode-benchmarks/build/${BENCHMARK_DIRECTORY} ${OUTPUT}
+echo "Benchmark results saved in ${OUTPUT}"


### PR DESCRIPTION
Reducing the noise in the logging from our benchmark framework.

Printing test log messages to stdout when running a benchmark, to watch the
progress.

Logging progress every 10 seconds in the yardstick task

Reporting the throughput and latency every 10 seconds while running a
benchmark. Each client currently reports it's own numbers.