### PR TITLE
GEODE-9176: Automatically pass properties to benchmark JVMs

### DIFF
--- a/geode-benchmarks/build.gradle
+++ b/geode-benchmarks/build.gradle
@@ -94,38 +94,51 @@ task benchmark(type: Test) {
   systemProperty 'TEST_HOSTS', project.findProperty('hosts')
   systemProperty 'TEST_METADATA', project.findProperty('metadata')
   systemProperty 'OUTPUT_DIR', outputDir
+
+  //Set all project properties starting with "benchmark." as system properties in the test
+  //JVM
+  project.properties.findAll {
+    it.key.startsWith("benchmark.")
+  }.each {
+    systemProperty(it.getKey(), it.getValue())
+  }
+
+  //------------------------------------------------------------
+  //Legacy properties - these properties were added before the benchmark.
+  //prefix convention. They will be passed on to the JVM for now to not break
+  //CI or peoples scripts. Remove these soon!
+  //------------------------------------------------------------
   if (project.hasProperty('withGc')) {
-    systemProperty 'withGc', project.findProperty('withGc')
+    systemProperty 'benchmark.withGc', project.findProperty('withGc')
   }
   if (project.hasProperty('withHeap')) {
-    systemProperty 'withHeap', project.findProperty('withHeap')
+    systemProperty 'benchmark.withHeap', project.findProperty('withHeap')
   }
   if (project.hasProperty('withThreads')) {
-    systemProperty 'withThreads', project.findProperty('withThreads')
+    systemProperty 'benchmark.withThreads', project.findProperty('withThreads')
   }
   if (project.hasProperty('withWarmup')) {
-    systemProperty 'withWarmup', project.findProperty('withWarmup')
+    systemProperty 'benchmark.withWarmup', project.findProperty('withWarmup')
   }
   if (project.hasProperty('withDuration')) {
-    systemProperty 'withDuration', project.findProperty('withDuration')
+    systemProperty 'benchmark.withDuration', project.findProperty('withDuration')
   }
 
-  systemProperty 'withSsl', project.hasProperty('withSsl')
-  systemProperty 'withSslProtocols', project.findProperty('withSslProtocols')
-  systemProperty 'withSslCiphers', project.findProperty('withSslCiphers')
+  systemProperty 'benchmark.withSsl', project.hasProperty('withSsl')
+  systemProperty 'benchmark.withSslProtocols', project.findProperty('withSslProtocols')
+  systemProperty 'benchmark.withSslCiphers', project.findProperty('withSslCiphers')
 
   if (project.hasProperty('withSniProxy')) {
-    systemProperty 'withSniProxy', project.findProperty('withSniProxy')
+    systemProperty 'benchmark.withSniProxy', project.findProperty('withSniProxy')
   }
-  systemProperty 'withSniProxyImage', project.findProperty('withSniProxyImage')
+  systemProperty 'benchmark.withSniProxyImage', project.findProperty('withSniProxyImage')
 
   if (project.hasProperty('withRouter')) {
-    systemProperty 'withRouter', project.findProperty('withRouter')
+    systemProperty 'benchmark.withRouter', project.findProperty('withRouter')
   }
-  systemProperty 'withRouterImage', project.findProperty('withRouterImage')
+  systemProperty 'benchmark.withRouterImage', project.findProperty('withRouterImage')
 
-  systemProperty 'withSecurityManager', project.hasProperty('withSecurityManager')
-  systemProperty 'benchmark.profiler.argument', project.findProperty('benchmark.profiler.argument')
+  systemProperty 'benchmark.withSecurityManager', project.hasProperty('withSecurityManager')
 
 
   doFirst {

--- a/geode-benchmarks/build.gradle
+++ b/geode-benchmarks/build.gradle
@@ -73,6 +73,10 @@ test{
     logger.quiet "Executing test ${desc.className}.${desc.name} with result: ${result.resultType}"
   }
   useJUnitPlatform()
+  systemProperty 'org.slf4j.simpleLogger.showDateTime', 'true'
+  systemProperty 'org.slf4j.simpleLogger.dateTimeFormat', 'yyyy-MM-dd HH:mm:ss.SSS'
+  systemProperty 'org.slf4j.simpleLogger.showThreadNam', 'false'
+  systemProperty 'org.slf4j.simpleLogger.showShortLogName', 'true'
 }
 
 task benchmark(type: Test) {
@@ -83,7 +87,10 @@ task benchmark(type: Test) {
   testClassesDirs = project.sourceSets.main.output.classesDirs
   classpath = project.sourceSets.main.runtimeClasspath
   useJUnitPlatform()
-  testLogging { exceptionFormat = 'full' }
+  testLogging {
+    exceptionFormat = 'full'
+    showStandardStreams = true
+  }
 
   exclude "**/NoopBenchmark.class"
   exclude "**/P2pPartitionedPutLongBenchmark.class"
@@ -91,6 +98,10 @@ task benchmark(type: Test) {
   forkEvery 1
   failFast = true
 
+  systemProperty 'org.slf4j.simpleLogger.showDateTime', 'true'
+  systemProperty 'org.slf4j.simpleLogger.dateTimeFormat', 'yyyy-MM-dd HH:mm:ss.SSS'
+  systemProperty 'org.slf4j.simpleLogger.showThreadName', 'false'
+  systemProperty 'org.slf4j.simpleLogger.showShortLogName', 'true'
   systemProperty 'TEST_HOSTS', project.findProperty('hosts')
   systemProperty 'TEST_METADATA', project.findProperty('metadata')
   systemProperty 'OUTPUT_DIR', outputDir

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/GcParameters.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/GcParameters.java
@@ -28,7 +28,7 @@ public class GcParameters {
 
   public static void configure(final TestConfig testConfig) {
     final GcImplementation gcImplementation =
-        GcImplementation.valueOf(System.getProperty("withGc", "CMS"));
+        GcImplementation.valueOf(System.getProperty("benchmark.withGc", "CMS"));
     logger.info("Configuring {} GC.", gcImplementation);
     switch (gcImplementation) {
       case CMS:

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/HeapParameters.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/parameters/HeapParameters.java
@@ -26,7 +26,7 @@ public class HeapParameters {
   private static final Logger logger = LoggerFactory.getLogger(HeapParameters.class);
 
   public static void configure(final TestConfig testConfig) {
-    final String heap = System.getProperty("withHeap", "8g");
+    final String heap = System.getProperty("benchmark.withHeap", "8g");
     logger.info("Configuring heap parameters {}.", heap);
     configureGeodeProductJvms(testConfig, "-Xmx" + heap, "-Xms" + heap);
   }

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/topology/ClientServerTopologyWithRouterAndSniProxy.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/topology/ClientServerTopologyWithRouterAndSniProxy.java
@@ -35,8 +35,8 @@ import org.apache.geode.benchmark.tasks.StopRouter;
 import org.apache.geode.perftest.TestConfig;
 
 public class ClientServerTopologyWithRouterAndSniProxy extends ClientServerTopologyWithSniProxy {
-  public static final String WITH_ROUTER_PROPERTY = "withRouter";
-  public static final String WITH_ROUTER_IMAGE_PROPERTY = "withRouterImage";
+  public static final String WITH_ROUTER_PROPERTY = "benchmark.withRouter";
+  public static final String WITH_ROUTER_IMAGE_PROPERTY = "benchmark.withRouterImage";
 
   private static final int NUM_LOCATORS = 1;
   private static final int NUM_SERVERS = 2;

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/topology/ClientServerTopologyWithSniProxy.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/topology/ClientServerTopologyWithSniProxy.java
@@ -40,8 +40,8 @@ import org.apache.geode.benchmark.tasks.StopSniProxy;
 import org.apache.geode.perftest.TestConfig;
 
 public class ClientServerTopologyWithSniProxy extends Topology {
-  public static final String WITH_SNI_PROXY_PROPERTY = "withSniProxy";
-  public static final String WITH_SNI_PROXY_IMAGE_PROPERTY = "withSniProxyImage";
+  public static final String WITH_SNI_PROXY_PROPERTY = "benchmark.withSniProxy";
+  public static final String WITH_SNI_PROXY_IMAGE_PROPERTY = "benchmark.withSniProxyImage";
 
   private static final int NUM_LOCATORS = 1;
   private static final int NUM_SERVERS = 2;

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/topology/Topology.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/topology/Topology.java
@@ -25,14 +25,14 @@ import org.apache.geode.benchmark.parameters.ProfilerParameters;
 import org.apache.geode.perftest.TestConfig;
 
 public abstract class Topology {
-  public static final String WITH_SSL_PROPERTY = "withSsl";
-  static final String WITH_SSL_ARGUMENT = "-DwithSsl=true";
+  public static final String WITH_SSL_PROPERTY = "benchmark.withSsl";
+  static final String WITH_SSL_ARGUMENT = "-Dbenchmark.withSsl=true";
 
-  public static final String WITH_SSL_PROTOCOLS_PROPERTY = "withSslProtocols";
-  public static final String WITH_SSL_CIPHERS_PROPERTY = "withSslCiphers";
+  public static final String WITH_SSL_PROTOCOLS_PROPERTY = "benchmark.withSslProtocols";
+  public static final String WITH_SSL_CIPHERS_PROPERTY = "benchmark.withSslCiphers";
 
-  public static final String WITH_SECURITY_MANAGER_PROPERTY = "withSecurityManager";
-  static final String WITH_SECURITY_MANAGER_ARGUMENT = "-DwithSecurityManager=true";
+  public static final String WITH_SECURITY_MANAGER_PROPERTY = "benchmark.withSecurityManager";
+  static final String WITH_SECURITY_MANAGER_ARGUMENT = "-Dbenchmark.withSecurityManager=true";
 
   static void configureCommon(TestConfig config) {
     JvmParameters.configure(config);

--- a/geode-benchmarks/src/test/java/org/apache/geode/benchmark/parameters/GcParametersTest.java
+++ b/geode-benchmarks/src/test/java/org/apache/geode/benchmark/parameters/GcParametersTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.apache.geode.perftest.TestConfig;
 
 class GcParametersTest {
-  private static final String WITH_GC = "withGc";
+  private static final String WITH_GC = "benchmark.withGc";
   private static final String JAVA_RUNTIME_VERSION = "java.runtime.version";
   private static final String XX_USE_ZGC = "-XX:+UseZGC";
   private static final String XX_USE_G_1_GC = "-XX:+UseG1GC";

--- a/geode-benchmarks/src/test/java/org/apache/geode/benchmark/parameters/HeapParametersTest.java
+++ b/geode-benchmarks/src/test/java/org/apache/geode/benchmark/parameters/HeapParametersTest.java
@@ -30,7 +30,7 @@ import org.apache.geode.perftest.TestConfig;
 
 class HeapParametersTest {
 
-  private static final String WITH_HEAP = "withHeap";
+  private static final String WITH_HEAP = "benchmark.withHeap";
 
   private Properties systemProperties;
 

--- a/geode-benchmarks/src/test/java/org/apache/geode/benchmark/tests/ClientServerBenchmarkTest.java
+++ b/geode-benchmarks/src/test/java/org/apache/geode/benchmark/tests/ClientServerBenchmarkTest.java
@@ -56,40 +56,40 @@ class GeodeBenchmarkTest {
 
   @AfterAll
   public static void afterAll() {
-    System.clearProperty("withSniProxy");
+    System.clearProperty("benchmark.withSniProxy");
   }
 
   @Test
   public void withoutSniProxy() {
-    System.clearProperty("withSniProxy");
+    System.clearProperty("benchmark.withSniProxy");
     config = ClientServerBenchmark.createConfig();
     assertThat(config.getBefore()).doesNotContain(startHAProxyStep, startEnvoyStep);
   }
 
   @Test
   public void withSniProxyInvalid() {
-    System.setProperty("withSniProxy", "invalid");
+    System.setProperty("benchmark.withSniProxy", "invalid");
     assertThatThrownBy(() -> ClientServerBenchmark.createConfig())
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   public void withSniProxyDefault() {
-    System.setProperty("withSniProxy", "");
+    System.setProperty("benchmark.withSniProxy", "");
     config = ClientServerBenchmark.createConfig();
     assertThat(config.getBefore()).contains(startHAProxyStep).doesNotContain(startEnvoyStep);
   }
 
   @Test
   public void withSniProxyHAProxy() {
-    System.setProperty("withSniProxy", "HAProxy");
+    System.setProperty("benchmark.withSniProxy", "HAProxy");
     config = ClientServerBenchmark.createConfig();
     assertThat(config.getBefore()).contains(startHAProxyStep);
   }
 
   @Test
   public void withSniProxyEnvoy() {
-    System.setProperty("withSniProxy", "Envoy");
+    System.setProperty("benchmark.withSniProxy", "Envoy");
     config = ClientServerBenchmark.createConfig();
     assertThat(config.getBefore()).contains(startEnvoyStep);
   }

--- a/geode-benchmarks/src/test/java/org/apache/geode/benchmark/topology/ClientServerTopologyTest.java
+++ b/geode-benchmarks/src/test/java/org/apache/geode/benchmark/topology/ClientServerTopologyTest.java
@@ -43,17 +43,18 @@ public class ClientServerTopologyTest {
 
   @Test
   public void configWithSsl() {
-    System.setProperty("withSsl", "true");
+    System.setProperty("benchmark.withSsl", "true");
     TestConfig testConfig = new TestConfig();
     ClientServerTopology.configure(testConfig);
-    assertThat(testConfig.getJvmArgs().get(CLIENT.name())).contains("-DwithSsl=true");
+    assertThat(testConfig.getJvmArgs().get(CLIENT.name())).contains("-Dbenchmark.withSsl=true");
   }
 
   @Test
   public void configWithNoSsl() {
     TestConfig testConfig = new TestConfig();
     ClientServerTopology.configure(testConfig);
-    assertThat(testConfig.getJvmArgs().get(CLIENT.name())).doesNotContain("-DwithSsl=true");
+    assertThat(testConfig.getJvmArgs().get(CLIENT.name()))
+        .doesNotContain("-Dbenchmark.withSsl=true");
   }
 
   @Test
@@ -61,27 +62,29 @@ public class ClientServerTopologyTest {
     TestConfig testConfig = new TestConfig();
     ClientServerTopology.configure(testConfig);
     assertThat(testConfig.getJvmArgs().get(CLIENT.name()))
-        .doesNotContain("-DwithSecurityManager=true");
+        .doesNotContain("-Dbenchmark.withSecurityManager=true");
   }
 
   @Test
   public void configWithSecurityManager() {
-    System.setProperty("withSecurityManager", "true");
+    System.setProperty("benchmark.withSecurityManager", "true");
     TestConfig testConfig = new TestConfig();
     ClientServerTopology.configure(testConfig);
-    assertThat(testConfig.getJvmArgs().get(CLIENT.name())).contains("-DwithSecurityManager=true");
+    assertThat(testConfig.getJvmArgs().get(CLIENT.name()))
+        .contains("-Dbenchmark.withSecurityManager=true");
   }
 
   @Test
   public void configWithSecurityManagerAndSslAndJava11() {
-    System.setProperty("withSecurityManager", "true");
+    System.setProperty("benchmark.withSecurityManager", "true");
     System.setProperty("java.runtime.version", "11.0.4+11");
-    System.setProperty("withSsl", "true");
+    System.setProperty("benchmark.withSsl", "true");
     TestConfig testConfig = new TestConfig();
 
     ClientServerTopology.configure(testConfig);
 
-    assertThat(testConfig.getJvmArgs().get(CLIENT.name())).contains("-DwithSecurityManager=true");
-    assertThat(testConfig.getJvmArgs().get(CLIENT.name())).contains("-DwithSsl=true");
+    assertThat(testConfig.getJvmArgs().get(CLIENT.name()))
+        .contains("-Dbenchmark.withSecurityManager=true");
+    assertThat(testConfig.getJvmArgs().get(CLIENT.name())).contains("-Dbenchmark.withSsl=true");
   }
 }

--- a/geode-benchmarks/src/test/java/org/apache/geode/benchmark/topology/ClientServerTopologyWithSniProxyTest.java
+++ b/geode-benchmarks/src/test/java/org/apache/geode/benchmark/topology/ClientServerTopologyWithSniProxyTest.java
@@ -51,7 +51,7 @@ public class ClientServerTopologyWithSniProxyTest {
     System.setProperty(WITH_SNI_PROXY_PROPERTY, sniProxyImplementation.name());
     final TestConfig testConfig = new TestConfig();
     ClientServerTopologyWithSniProxy.configure(testConfig);
-    assertThat(testConfig.getJvmArgs().get(CLIENT.name())).contains("-DwithSsl=true");
+    assertThat(testConfig.getJvmArgs().get(CLIENT.name())).contains("-Dbenchmark.withSsl=true");
   }
 
 }

--- a/harness/build.gradle
+++ b/harness/build.gradle
@@ -49,7 +49,6 @@ dependencies {
   compile(group: 'commons-io', name: 'commons-io', version: project.'commons-io.version')
   compile(group: 'org.yardstickframework', name: 'yardstick', version: project.'yardstick.version')
   compile(group: 'org.hdrhistogram', name: 'HdrHistogram', version: project.'HdrHistogram.version')
-  compile(group: 'org.json', name: 'json', version: project.'JSON.version')
   compile(group: 'org.apache.geode', name: 'geode-core', version: geodeVersion)
   testCompile(group: 'org.mockito', name: 'mockito-all', version: project.'mockito-all.version')
   testCompile(group: 'org.awaitility', name: 'awaitility', version: project.'awaitility.version')

--- a/harness/src/main/java/org/apache/geode/perftest/BenchmarkProperties.java
+++ b/harness/src/main/java/org/apache/geode/perftest/BenchmarkProperties.java
@@ -1,0 +1,25 @@
+package org.apache.geode.perftest;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BenchmarkProperties {
+
+  public static Map<String, List<String>> getDefaultJVMArgs() {
+    Map<String, List<String>> results = new HashMap<>();
+    System.getProperties().stringPropertyNames().stream()
+        .filter(name -> name.startsWith("benchmark.system."))
+        .forEach(name -> {
+          String shortName = name.replace("benchmark.system.", "");
+          String[] roleAndProperty = shortName.split("\\.", 2);
+          String role = roleAndProperty[0];
+          String property = roleAndProperty[1];
+          String value = System.getProperty(name);
+          List<String> roleProperties = results.computeIfAbsent(role, key -> new ArrayList<>());
+          roleProperties.add("-D" + property + "=" + value);
+        });
+    return results;
+  }
+}

--- a/harness/src/main/java/org/apache/geode/perftest/BenchmarkProperties.java
+++ b/harness/src/main/java/org/apache/geode/perftest/BenchmarkProperties.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.geode.perftest;
 
 import java.util.ArrayList;
@@ -7,6 +24,11 @@ import java.util.Map;
 
 public class BenchmarkProperties {
 
+  /**
+   * Read the current system properties and find any system properties that start
+   * with "benchmark.system.ROLE" Returns a map of ROLE-> system properties for that
+   * role.
+   */
   public static Map<String, List<String>> getDefaultJVMArgs() {
     Map<String, List<String>> results = new HashMap<>();
     System.getProperties().stringPropertyNames().stream()

--- a/harness/src/main/java/org/apache/geode/perftest/TestConfig.java
+++ b/harness/src/main/java/org/apache/geode/perftest/TestConfig.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +38,7 @@ public class TestConfig implements Serializable {
 
   private final WorkloadConfig workloadConfig = new WorkloadConfig();
   private Map<String, Integer> roles = new LinkedHashMap<>();
-  private Map<String, List<String>> jvmArgs = new HashMap<>();
+  private Map<String, List<String>> jvmArgs = BenchmarkProperties.getDefaultJVMArgs();
   private List<TestStep> before = new ArrayList<>();
   private List<TestStep> workload = new ArrayList<>();
   private List<TestStep> after = new ArrayList<>();

--- a/harness/src/main/java/org/apache/geode/perftest/TestRunners.java
+++ b/harness/src/main/java/org/apache/geode/perftest/TestRunners.java
@@ -38,8 +38,8 @@ import org.apache.geode.perftest.runner.DefaultTestRunner;
  */
 public class TestRunners {
 
-  public static final String TEST_HOSTS = "TEST_HOSTS";
-  public static final String OUTPUT_DIR = "OUTPUT_DIR";
+  public static final String TEST_HOSTS = "benchmark.TEST_HOSTS";
+  public static final String OUTPUT_DIR = "benchmark.OUTPUT_DIR";
 
   public static final String[] JVM_ARGS_SMALL_SIZE = new String[] {
       "-XX:CMSInitiatingOccupancyFraction=60",
@@ -91,7 +91,7 @@ public class TestRunners {
   static TestRunner defaultRunner(String testHosts, File outputDir) {
     if (testHosts == null) {
       throw new IllegalStateException(
-          "You must set the TEST_HOSTS system property to a comma separated list of hosts to run the benchmarks on.");
+          "You must set the benchmark.TEST_HOSTS system property to a comma separated list of hosts to run the benchmarks on.");
     }
 
     String userName = System.getProperty("user.name");

--- a/harness/src/main/java/org/apache/geode/perftest/WorkloadConfig.java
+++ b/harness/src/main/java/org/apache/geode/perftest/WorkloadConfig.java
@@ -42,15 +42,15 @@ public class WorkloadConfig implements Serializable {
   public WorkloadConfig() {}
 
   public void durationSeconds(long durationSeconds) {
-    this.durationSeconds = Long.getLong("withDuration", durationSeconds);
+    this.durationSeconds = Long.getLong("benchmark.withDuration", durationSeconds);
   }
 
   public void warmupSeconds(long warmupSeconds) {
-    this.warmupSeconds = Long.getLong("withWarmup", warmupSeconds);
+    this.warmupSeconds = Long.getLong("benchmark.withWarmup", warmupSeconds);
   }
 
   public void threads(int threads) {
-    this.threads = Integer.getInteger("withThreads", threads);
+    this.threads = Integer.getInteger("benchmark.withThreads", threads);
   }
 
   public long getDurationSeconds() {

--- a/harness/src/main/java/org/apache/geode/perftest/jvms/JVMLauncher.java
+++ b/harness/src/main/java/org/apache/geode/perftest/jvms/JVMLauncher.java
@@ -91,7 +91,7 @@ class JVMLauncher {
     command.add("-D" + RemoteJVMFactory.JVM_ID + "=" + jvmConfig.getId());
     command.add("-D" + RemoteJVMFactory.OUTPUT_DIR + "=" + jvmConfig.getOutputDir());
 
-    if (jvmConfig.getJvmArgs().contains("-DwithSsl=true")) {
+    if (jvmConfig.getJvmArgs().contains("-Dbenchmark.withSsl=true")) {
       command
           .add("-Dgemfire." + SSL_KEYSTORE + "=" + jvmConfig.getLibDir() + "/temp-self-signed.jks");
       command.add("-Dgemfire." + SSL_KEYSTORE_PASSWORD + "=123456");

--- a/harness/src/main/java/org/apache/geode/perftest/runner/DefaultTestRunner.java
+++ b/harness/src/main/java/org/apache/geode/perftest/runner/DefaultTestRunner.java
@@ -74,12 +74,16 @@ public class DefaultTestRunner implements TestRunner {
     }
 
     benchmarkOutput.mkdirs();
+    Properties properties = new Properties();
+    addVersionProperties(properties, getVersionProperties());
+    addSystemProperties(properties);
+    logger.info("Benchmark Properties {}", properties);
+
+
     String metadataFilename = outputDir + "/testrunner.properties";
     Path metadataOutput = Paths.get(metadataFilename);
 
     if (!metadataOutput.toFile().exists()) {
-      Properties properties = new Properties(System.getProperties());
-      addVersionProperties(properties, getVersionProperties());
       try (FileWriter writer = new FileWriter(metadataOutput.toFile().getAbsoluteFile())) {
         properties.store(writer, "Benchmark metadata generated while running tests");
       }
@@ -110,6 +114,12 @@ public class DefaultTestRunner implements TestRunner {
       remoteJVMs.closeInfra();
     }
 
+  }
+
+  private void addSystemProperties(Properties properties) {
+    System.getProperties().stringPropertyNames().stream()
+        .filter(name -> name.startsWith("benchmark."))
+        .forEach(name -> properties.setProperty(name, System.getProperty(name)));
   }
 
   private void addVersionProperties(Properties jsonMetadata, Properties versionProperties) {

--- a/harness/src/test/java/org/apache/geode/perftest/BenchmarkPropertiesTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/BenchmarkPropertiesTest.java
@@ -1,0 +1,24 @@
+package org.apache.geode.perftest;
+
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class BenchmarkPropertiesTest {
+
+  @Test
+  public void canParsePropertiesForRoles() {
+    System.setProperty("benchmark.system.role1.p1", "v1");
+    System.setProperty("benchmark.system.role1.p2", "v2");
+
+    Map<String, List<String>> defaultArgs =
+        BenchmarkProperties.getDefaultJVMArgs();
+
+    Assertions.assertThat(defaultArgs).containsOnlyKeys("role1");
+
+    Assertions.assertThat(defaultArgs.get("role1")).containsExactlyInAnyOrder("-Dp1=v1", "-Dp2=v2");
+  }
+
+}

--- a/harness/src/test/java/org/apache/geode/perftest/BenchmarkPropertiesTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/BenchmarkPropertiesTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.geode.perftest;
 
 import java.util.List;

--- a/harness/src/test/java/org/apache/geode/perftest/TestRunnerIntegrationTest.java
+++ b/harness/src/test/java/org/apache/geode/perftest/TestRunnerIntegrationTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.geode.perftest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -26,6 +27,7 @@ import java.nio.file.Path;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -38,6 +40,7 @@ import org.apache.geode.perftest.yardstick.analysis.YardstickThroughputSensorPar
 
 public class TestRunnerIntegrationTest {
 
+  public static final String TEST_PROPERTY = "benchmark.system.all.prop3";
   private TestRunner runner;
 
   @TempDir
@@ -49,6 +52,11 @@ public class TestRunnerIntegrationTest {
   void beforeEach() {
     runner = new DefaultTestRunner(new RemoteJVMFactory(new LocalInfrastructureFactory()),
         outputDir);
+  }
+
+  @AfterEach()
+  void clearProperty() {
+    System.clearProperty(TEST_PROPERTY);
   }
 
   @Test
@@ -93,6 +101,7 @@ public class TestRunnerIntegrationTest {
 
   @Test
   public void configuresJVMOptions() throws Exception {
+    System.setProperty(TEST_PROPERTY, "p3");
     runner.runTest(() -> {
       TestConfig testConfig = new TestConfig();
       testConfig.role("all", 1);
@@ -102,6 +111,7 @@ public class TestRunnerIntegrationTest {
             "Expecting system property to be set in launched JVM, but it was not present.");
         assertEquals(5, Integer.getInteger("prop2").intValue(),
             "Expecting system property to be set in launched JVM, but it was not present.");
+        assertThat(System.getProperty("prop3")).isEqualTo("p3");
       }, "all");
       return testConfig;
     });

--- a/infrastructure/src/main/java/org/apache/geode/infrastructure/BenchmarkMetadata.java
+++ b/infrastructure/src/main/java/org/apache/geode/infrastructure/BenchmarkMetadata.java
@@ -44,6 +44,6 @@ public class BenchmarkMetadata {
   }
 
   public static String benchmarkMetadataFileName(String tag) {
-    return benchmarkConfigDirectory() + "/" + tag + "-metadata.json";
+    return benchmarkConfigDirectory() + "/" + tag + "-cluster-launch.properties";
   }
 }

--- a/infrastructure/src/main/java/org/apache/geode/infrastructure/aws/LaunchCluster.java
+++ b/infrastructure/src/main/java/org/apache/geode/infrastructure/aws/LaunchCluster.java
@@ -18,6 +18,7 @@ package org.apache.geode.infrastructure.aws;
 
 import static java.lang.Thread.sleep;
 
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,11 +32,10 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Properties;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.AllocateHostsRequest;
 import software.amazon.awssdk.services.ec2.model.AllocateHostsResponse;
@@ -241,19 +241,21 @@ public class LaunchCluster {
   private static void createMetadata(String benchmarkTag, List<String> publicIps)
       throws IOException {
     UUID instanceId = UUID.randomUUID();
-    JSONObject metadataJSON = new JSONObject();
-
-    metadataJSON.put("instanceId", instanceId.toString());
-    metadataJSON.put("publicIps", new JSONArray(publicIps));
+    // TODO - Filter out only benchmark properties from system properties? Maybe not necessary.
+    Properties metadata = new Properties(System.getProperties());
+    metadata.setProperty("benchmark.instanceId", instanceId.toString());
+    metadata.setProperty("benchmark.publicIps", String.join(",", publicIps));
     Path configDirectory = Paths.get(BenchmarkMetadata.benchmarkConfigDirectory());
 
     if (!configDirectory.toFile().exists()) {
       Files.createDirectories(Paths.get(BenchmarkMetadata.benchmarkConfigDirectory()));
     }
 
-    Path metadata = Files.write(Paths.get(AwsBenchmarkMetadata.metadataFileName(benchmarkTag)),
-        metadataJSON.toString().getBytes());
-    Files.setPosixFilePermissions(metadata, PosixFilePermissions.fromString("rw-------"));
+    Path metadataPath = Paths.get(AwsBenchmarkMetadata.metadataFileName(benchmarkTag));
+    try (FileWriter writer = new FileWriter(metadataPath.toFile())) {
+      metadata.store(writer, "Benchmark metadata generated during cluster launch");
+    }
+    Files.setPosixFilePermissions(metadataPath, PosixFilePermissions.fromString("rw-------"));
   }
 
   private static void createLaunchTemplate(String benchmarkTag, Image newestImage) {

--- a/infrastructure/src/main/java/org/apache/geode/infrastructure/aws/LaunchCluster.java
+++ b/infrastructure/src/main/java/org/apache/geode/infrastructure/aws/LaunchCluster.java
@@ -241,7 +241,6 @@ public class LaunchCluster {
   private static void createMetadata(String benchmarkTag, List<String> publicIps)
       throws IOException {
     UUID instanceId = UUID.randomUUID();
-    // TODO - Filter out only benchmark properties from system properties? Maybe not necessary.
     Properties metadata = new Properties(System.getProperties());
     metadata.setProperty("benchmark.instanceId", instanceId.toString());
     metadata.setProperty("benchmark.publicIps", String.join(",", publicIps));


### PR DESCRIPTION
Converting all of the system properties we use in the benchmarks to start with the benchmark
prefix. Changing the gradle build to copy all benchmark.* properties as system
roperties in the test.
    
For now, also copying the old set of withXXX properties to not break peoples scripts or CI.

Adding a way to automatically set system properties in test JVMs. Just add a property
with the prefix benchmark.system.ROLE, where ROLE is the role of jvms to target. Eg

benchmark.system.server.gemfire.disablePartitionedRegionBucketAck=true would set
gemfire.disablePartitionedRegionBucketAck=true  in the server JVMs.

Getting rid of problematic org.json dependency, and also making
sure we capture *all* system properties that might effect the behavior of the
test.