### PR TITLE
Add ManualRedisTopology test for hosts and ports

### DIFF
--- a/geode-benchmarks/src/test/java/org/apache/geode/benchmark/redis/topology/ManualRedisTopologyTest.java
+++ b/geode-benchmarks/src/test/java/org/apache/geode/benchmark/redis/topology/ManualRedisTopologyTest.java
@@ -58,7 +58,7 @@ public class ManualRedisTopologyTest {
 
   @Test
   @SetSystemProperty(key = WITH_REDIS_SERVERS_PROPERTY, value = "a:1;b:2;c:3")
-  public void configureWithMultipleServersAndPorts() {
+  public void configureWithMultipleServersWithHostsAndPorts() {
     final TestConfig testConfig = new TestConfig();
     ManualRedisTopology.configure(testConfig);
     assertThat(testConfig.getBefore().stream().map(TestStep::getTask)

--- a/geode-benchmarks/src/test/java/org/apache/geode/benchmark/redis/topology/ManualRedisTopologyTest.java
+++ b/geode-benchmarks/src/test/java/org/apache/geode/benchmark/redis/topology/ManualRedisTopologyTest.java
@@ -45,7 +45,7 @@ public class ManualRedisTopologyTest {
 
   @Test
   @SetSystemProperty(key = WITH_REDIS_SERVERS_PROPERTY, value = "a;b;c")
-  public void configureWithMultipleServer() {
+  public void configureWithMultipleServers() {
     final TestConfig testConfig = new TestConfig();
     ManualRedisTopology.configure(testConfig);
     assertThat(testConfig.getBefore().stream().map(TestStep::getTask)
@@ -55,6 +55,20 @@ public class ManualRedisTopologyTest {
             createUnresolved("a", REDIS_PORT), createUnresolved("b", REDIS_PORT),
             createUnresolved("c", REDIS_PORT)));
   }
+
+  @Test
+  @SetSystemProperty(key = WITH_REDIS_SERVERS_PROPERTY, value = "a:1;b:2;c:3")
+  public void configureWithMultipleServersAndPorts() {
+    final TestConfig testConfig = new TestConfig();
+    ManualRedisTopology.configure(testConfig);
+    assertThat(testConfig.getBefore().stream().map(TestStep::getTask)
+                   .filter(InitRedisServersAttribute.class::isInstance)
+                   .map(InitRedisServersAttribute.class::cast)
+                   .findFirst()).hasValueSatisfying(t -> assertThat(t.getServers()).containsExactly(
+        createUnresolved("a", 1), createUnresolved("b", 2),
+        createUnresolved("c", 3)));
+  }
+
 
   @Test
   @ClearSystemProperty(key = WITH_REDIS_SERVERS_PROPERTY)

--- a/geode-benchmarks/src/test/java/org/apache/geode/benchmark/redis/topology/ManualRedisTopologyTest.java
+++ b/geode-benchmarks/src/test/java/org/apache/geode/benchmark/redis/topology/ManualRedisTopologyTest.java
@@ -62,11 +62,11 @@ public class ManualRedisTopologyTest {
     final TestConfig testConfig = new TestConfig();
     ManualRedisTopology.configure(testConfig);
     assertThat(testConfig.getBefore().stream().map(TestStep::getTask)
-                   .filter(InitRedisServersAttribute.class::isInstance)
-                   .map(InitRedisServersAttribute.class::cast)
-                   .findFirst()).hasValueSatisfying(t -> assertThat(t.getServers()).containsExactly(
-        createUnresolved("a", 1), createUnresolved("b", 2),
-        createUnresolved("c", 3)));
+        .filter(InitRedisServersAttribute.class::isInstance)
+        .map(InitRedisServersAttribute.class::cast)
+        .findFirst()).hasValueSatisfying(t -> assertThat(t.getServers()).containsExactly(
+            createUnresolved("a", 1), createUnresolved("b", 2),
+            createUnresolved("c", 3)));
   }
 
   @Test

--- a/geode-benchmarks/src/test/java/org/apache/geode/benchmark/redis/topology/ManualRedisTopologyTest.java
+++ b/geode-benchmarks/src/test/java/org/apache/geode/benchmark/redis/topology/ManualRedisTopologyTest.java
@@ -69,7 +69,6 @@ public class ManualRedisTopologyTest {
         createUnresolved("c", 3)));
   }
 
-
   @Test
   @ClearSystemProperty(key = WITH_REDIS_SERVERS_PROPERTY)
   public void configureWithNoServersThrows() {


### PR DESCRIPTION
Hosts and ports are currently configurable for `ManualRedisTopology`, adding a test verifying this behavior.