### PR TITLE
Remove file copy logging

### DIFF
--- a/harness/src/main/java/org/apache/geode/perftest/infrastructure/ssh/SshInfrastructure.java
+++ b/harness/src/main/java/org/apache/geode/perftest/infrastructure/ssh/SshInfrastructure.java
@@ -170,7 +170,6 @@ public class SshInfrastructure implements Infrastructure {
           }
 
           for (File file : files) {
-            logger.info("Copying " + file + " to " + address);
             client.newSCPFileTransfer().upload(new FileSystemFile(file), destDir);
           }
         } catch (IOException e) {


### PR DESCRIPTION
- This makes up almost ALL of the run output which doesn't seem to serve
  any useful purpose.