### PR TITLE
Removing references to Geode internal classes

### DIFF
--- a/geode-benchmarks/src/main/java/benchmark/geode/data/Portfolio.java
+++ b/geode-benchmarks/src/main/java/benchmark/geode/data/Portfolio.java
@@ -23,9 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.geode.internal.Assert;
-
-
 public class Portfolio {
 
   public enum Day {
@@ -88,7 +85,6 @@ public class Portfolio {
     collectionHolderMap.put("3", new CollectionHolder());
 
     unicodeṤtring = i % 2 == 0 ? "ṤṶẐ" : "ṤẐṶ";
-    Assert.assertTrue(unicodeṤtring.length() == 3);
   }
 
   public Portfolio(int i, int j) {

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/OQLQuery.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/OQLQuery.java
@@ -14,8 +14,6 @@
  */
 package org.apache.geode.benchmark.tasks;
 
-import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
-
 import java.io.Serializable;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
@@ -59,6 +57,7 @@ public class OQLQuery extends BenchmarkDriverAdapter implements Serializable {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public boolean test(final Map<Object, Object> ctx) throws Exception {
     final long minId =
         ThreadLocalRandom.current().nextLong(keyRange.getMin(), keyRange.getMax() - queryRange);
@@ -67,7 +66,7 @@ public class OQLQuery extends BenchmarkDriverAdapter implements Serializable {
     final Object result = query.execute(minId, maxId);
 
     if (isValidationEnabled) {
-      verifyResults(uncheckedCast(result), minId, maxId);
+      verifyResults((SelectResults<Portfolio>) result, minId, maxId);
     }
 
     return true;

--- a/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartServer.java
+++ b/geode-benchmarks/src/main/java/org/apache/geode/benchmark/tasks/StartServer.java
@@ -23,10 +23,10 @@ import java.io.File;
 import java.net.InetAddress;
 import java.util.Properties;
 
+import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.ConfigurationProperties;
-import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.pdx.ReflectionBasedAutoSerializer;
 import org.apache.geode.perftest.Task;
 import org.apache.geode.perftest.TestContext;
@@ -53,7 +53,7 @@ public class StartServer implements Task {
 
     final CacheFactory cacheFactory = new CacheFactory(properties);
     configureCacheFactory(cacheFactory, context);
-    final InternalCache cache = (InternalCache) cacheFactory.create();
+    final Cache cache = cacheFactory.create();
 
     final CacheServer cacheServer = configureCacheServer(cache.addCacheServer(), context);
     if (null != cacheServer) {


### PR DESCRIPTION
Geode internal classes shouldn't be used in the benchmarks. Using them makes it
harder to run tests against different versions of geode, since we don't make
garuantees about preserving the APIs of these classes between versions.